### PR TITLE
feat(Briefing): add native iOS PDF parsing with PDFKit

### DIFF
--- a/Sources/RZFlight/Briefing/Briefing.swift
+++ b/Sources/RZFlight/Briefing/Briefing.swift
@@ -154,6 +154,29 @@ public struct Briefing: Codable, Sendable {
     }
 }
 
+// MARK: - Memberwise Initializer
+
+extension Briefing {
+    /// Create a Briefing with all fields specified
+    public init(
+        id: String = UUID().uuidString,
+        createdAt: Date = Date(),
+        source: String,
+        route: Route? = nil,
+        notams: [Notam] = [],
+        validFrom: Date? = nil,
+        validTo: Date? = nil
+    ) {
+        self.id = id
+        self.createdAt = createdAt
+        self.source = source
+        self.route = route
+        self.notams = notams
+        self.validFrom = validFrom
+        self.validTo = validTo
+    }
+}
+
 // MARK: - Protocol Conformances
 
 extension Briefing: Identifiable {}

--- a/Sources/RZFlight/Briefing/ForeFlightParser.swift
+++ b/Sources/RZFlight/Briefing/ForeFlightParser.swift
@@ -1,0 +1,689 @@
+//
+//  ForeFlightParser.swift
+//  RZFlight
+//
+//  Native Swift parser for ForeFlight PDF briefings.
+//  Uses PDFKit for text extraction and ports logic from Python ForeFlightSource.
+//
+
+import Foundation
+import PDFKit
+
+/// Parser for ForeFlight briefing PDFs.
+///
+/// Extracts text from ForeFlight PDF briefings using PDFKit, handling:
+/// - Two-column landscape layouts
+/// - Route information (departure, destination, alternates, waypoints)
+/// - NOTAM sections organized by location
+///
+/// Example:
+/// ```swift
+/// let parser = ForeFlightParser()
+///
+/// // Parse from file URL
+/// let briefing = try parser.parse(url: fileURL)
+///
+/// // Or from raw PDF data
+/// let briefing = try parser.parse(data: pdfData)
+///
+/// // Access extracted data
+/// print(briefing.route?.departure)
+/// let runwayNotams = briefing.notams.runwayRelated()
+/// ```
+public final class ForeFlightParser: Sendable {
+
+    /// Errors that can occur during parsing
+    public enum ParserError: Error, LocalizedError {
+        case fileNotFound(URL)
+        case invalidPDF
+        case textExtractionFailed
+        case noContent
+
+        public var errorDescription: String? {
+            switch self {
+            case .fileNotFound(let url):
+                return "PDF file not found: \(url.path)"
+            case .invalidPDF:
+                return "Invalid or corrupted PDF file"
+            case .textExtractionFailed:
+                return "Failed to extract text from PDF"
+            case .noContent:
+                return "No content found in PDF"
+            }
+        }
+    }
+
+    // MARK: - Initialization
+
+    public init() {}
+
+    // MARK: - Public Parsing Interface
+
+    /// Parse a ForeFlight briefing PDF from a file URL.
+    ///
+    /// - Parameter url: URL to the PDF file
+    /// - Returns: Parsed Briefing object
+    /// - Throws: ParserError if parsing fails
+    public func parse(url: URL) throws -> Briefing {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ParserError.fileNotFound(url)
+        }
+
+        guard let document = PDFDocument(url: url) else {
+            throw ParserError.invalidPDF
+        }
+
+        return try parse(document: document)
+    }
+
+    /// Parse a ForeFlight briefing PDF from raw data.
+    ///
+    /// - Parameter data: Raw PDF data
+    /// - Returns: Parsed Briefing object
+    /// - Throws: ParserError if parsing fails
+    public func parse(data: Data) throws -> Briefing {
+        guard let document = PDFDocument(data: data) else {
+            throw ParserError.invalidPDF
+        }
+
+        return try parse(document: document)
+    }
+
+    /// Parse briefing from pre-extracted text.
+    ///
+    /// Useful when text has already been extracted from PDF.
+    ///
+    /// - Parameter text: Extracted text from briefing
+    /// - Returns: Parsed Briefing object
+    public func parse(text: String) -> Briefing {
+        let route = extractRoute(from: text)
+        let notams = extractNotams(from: text)
+
+        return Briefing(
+            source: "foreflight",
+            route: route,
+            notams: notams
+        )
+    }
+
+    // MARK: - Private PDF Extraction
+
+    private func parse(document: PDFDocument) throws -> Briefing {
+        let text = try extractText(from: document)
+
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ParserError.noContent
+        }
+
+        return parse(text: text)
+    }
+
+    /// Extract text from PDF, handling multi-column layouts.
+    private func extractText(from document: PDFDocument) throws -> String {
+        var textParts: [String] = []
+
+        for pageIndex in 0..<document.pageCount {
+            guard let page = document.page(at: pageIndex) else { continue }
+            if let pageText = extractPageText(from: page), !pageText.isEmpty {
+                textParts.append(pageText)
+            }
+        }
+
+        guard !textParts.isEmpty else {
+            throw ParserError.textExtractionFailed
+        }
+
+        return textParts.joined(separator: "\n\n")
+    }
+
+    /// Extract text from a single page, handling multi-column layouts.
+    ///
+    /// ForeFlight briefings often use two-column layouts in landscape mode.
+    /// This method detects such layouts and extracts columns separately.
+    private func extractPageText(from page: PDFPage) -> String? {
+        let bounds = page.bounds(for: .mediaBox)
+        let width = bounds.width
+        let height = bounds.height
+
+        // Check if landscape orientation (likely two-column NOTAM pages)
+        if width > height {
+            // Extract left and right columns separately using selection
+            let leftRect = CGRect(
+                x: bounds.minX,
+                y: bounds.minY,
+                width: width / 2,
+                height: height
+            )
+            let rightRect = CGRect(
+                x: bounds.midX,
+                y: bounds.minY,
+                width: width / 2,
+                height: height
+            )
+
+            let leftText = page.selection(for: leftRect)?.string ?? ""
+            let rightText = page.selection(for: rightRect)?.string ?? ""
+
+            // Combine columns - left first, then right
+            if !leftText.isEmpty && !rightText.isEmpty {
+                return leftText + "\n\n" + rightText
+            }
+            return leftText.isEmpty ? rightText : leftText
+        }
+
+        // Portrait mode - extract normally
+        return page.string
+    }
+
+    // MARK: - Route Extraction
+
+    private func extractRoute(from text: String) -> Route? {
+        var departure: String?
+        var destination: String?
+
+        // First, try to find explicit Departure and Destination labels
+        // These are the most reliable indicators in ForeFlight briefings
+        let depPattern = try! NSRegularExpression(
+            pattern: #"\bDeparture\s+([A-Z]{4})\b"#,
+            options: [.caseInsensitive]
+        )
+        let destPattern = try! NSRegularExpression(
+            pattern: #"\bDestination\s+([A-Z]{4})\b"#,
+            options: [.caseInsensitive]
+        )
+
+        if let depMatch = depPattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+           let destMatch = destPattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ) {
+            if let depRange = Range(depMatch.range(at: 1), in: text) {
+                departure = String(text[depRange]).uppercased()
+            }
+            if let destRange = Range(destMatch.range(at: 1), in: text) {
+                destination = String(text[destRange]).uppercased()
+            }
+        } else {
+            // Try other common patterns (in order of reliability)
+            let patterns = [
+                // "From: LFPG To: EGLL"
+                #"From:?\s*([A-Z]{4}).*?To:?\s*([A-Z]{4})"#,
+                // Route header "LFPG EGLL"
+                #"^Route:?\s*([A-Z]{4})\s+([A-Z]{4})"#,
+                // "LFPG to EGLL" or "LFPG - EGLL"
+                #"([A-Z]{4})\s*(?:to|->|→)\s*([A-Z]{4})"#,
+            ]
+
+            for pattern in patterns {
+                let regex = try! NSRegularExpression(
+                    pattern: pattern,
+                    options: [.caseInsensitive, .anchorsMatchLines, .dotMatchesLineSeparators]
+                )
+                if let match = regex.firstMatch(
+                    in: text,
+                    range: NSRange(text.startIndex..., in: text)
+                ) {
+                    if let depRange = Range(match.range(at: 1), in: text) {
+                        departure = String(text[depRange]).uppercased()
+                    }
+                    if let destRange = Range(match.range(at: 2), in: text) {
+                        destination = String(text[destRange]).uppercased()
+                    }
+                    break
+                }
+            }
+        }
+
+        // Fallback: try to find ICAO codes mentioned early in document
+        if departure == nil || destination == nil {
+            let icaoPattern = try! NSRegularExpression(
+                pattern: #"\b([A-Z]{4})\b"#,
+                options: []
+            )
+            let searchRange = String(text.prefix(2000))
+            let matches = icaoPattern.matches(
+                in: searchRange,
+                range: NSRange(searchRange.startIndex..., in: searchRange)
+            )
+
+            let excludedWords = Set([
+                "NOTAM", "METAR", "SPECI", "TEMPO", "BECMG", "NOSIG", "CAVOK",
+                "PROB", "FROM", "WIND", "AUTO"
+            ])
+
+            var airportCodes: [String] = []
+            for match in matches {
+                if let range = Range(match.range(at: 1), in: searchRange) {
+                    let code = String(searchRange[range])
+                    if !excludedWords.contains(code) {
+                        airportCodes.append(code)
+                    }
+                }
+            }
+
+            if airportCodes.count >= 2 {
+                if departure == nil {
+                    departure = airportCodes[0]
+                }
+                if destination == nil {
+                    destination = airportCodes[1]
+                }
+            }
+        }
+
+        guard let dep = departure else { return nil }
+
+        var route = Route(
+            departure: dep,
+            destination: destination ?? dep
+        )
+
+        // Try to extract alternates
+        let alternates = extractAlternates(from: text)
+        if !alternates.isEmpty {
+            route = Route(
+                departure: route.departure,
+                destination: route.destination,
+                alternates: alternates,
+                waypoints: route.waypoints
+            )
+        }
+
+        // Try to extract waypoints
+        let waypoints = extractWaypoints(from: text)
+        if !waypoints.isEmpty {
+            route = Route(
+                departure: route.departure,
+                destination: route.destination,
+                alternates: route.alternates,
+                waypoints: waypoints
+            )
+        }
+
+        return route
+    }
+
+    private func extractAlternates(from text: String) -> [String] {
+        var alternates: [String] = []
+
+        let patterns = [
+            #"Alternate[s]?:?\s*([A-Z]{4}(?:\s*,?\s*[A-Z]{4})*)"#,
+            #"ALT:?\s*([A-Z]{4}(?:\s*,?\s*[A-Z]{4})*)"#,
+        ]
+
+        let icaoPattern = try! NSRegularExpression(
+            pattern: #"[A-Z]{4}"#,
+            options: []
+        )
+
+        for pattern in patterns {
+            let regex = try! NSRegularExpression(
+                pattern: pattern,
+                options: [.caseInsensitive]
+            )
+            if let match = regex.firstMatch(
+                in: text,
+                range: NSRange(text.startIndex..., in: text)
+            ),
+               let groupRange = Range(match.range(at: 1), in: text) {
+                let group = String(text[groupRange])
+                let codes = icaoPattern.matches(
+                    in: group,
+                    range: NSRange(group.startIndex..., in: group)
+                )
+                for codeMatch in codes {
+                    if let codeRange = Range(codeMatch.range, in: group) {
+                        alternates.append(String(group[codeRange]))
+                    }
+                }
+            }
+        }
+
+        // Remove duplicates while preserving order
+        var seen = Set<String>()
+        return alternates.filter { seen.insert($0).inserted }
+    }
+
+    private func extractWaypoints(from text: String) -> [String] {
+        // Look for route string like "DCT POGOL DCT VESAN DCT"
+        let routePattern = try! NSRegularExpression(
+            pattern: #"Route:?\s*(.+?)(?:\n\n|\n[A-Z]{4}:|\nNOTAM)"#,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        )
+
+        guard let match = routePattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+              let groupRange = Range(match.range(at: 1), in: text) else {
+            return []
+        }
+
+        let routeStr = String(text[groupRange])
+
+        // Extract waypoint names (2-5 letter fixes, airways, etc.)
+        let waypointPattern = try! NSRegularExpression(
+            pattern: #"\b([A-Z]{2,5})\b"#,
+            options: []
+        )
+        let matches = waypointPattern.matches(
+            in: routeStr,
+            range: NSRange(routeStr.startIndex..., in: routeStr)
+        )
+
+        let excluded = Set([
+            "DCT", "VIA", "THEN", "TO", "FROM", "AND", "OR",
+            "IFR", "VFR", "FL", "ALT", "ROUTE"
+        ])
+
+        var waypoints: [String] = []
+        for wpMatch in matches {
+            if let range = Range(wpMatch.range(at: 1), in: routeStr) {
+                let wp = String(routeStr[range])
+                if !excluded.contains(wp) {
+                    waypoints.append(wp)
+                }
+            }
+        }
+
+        return waypoints
+    }
+
+    // MARK: - NOTAM Extraction
+
+    private func extractNotams(from text: String) -> [Notam] {
+        var notams: [Notam] = []
+
+        // Find NOTAM sections
+        let notamSections = findNotamSections(in: text)
+
+        for (sectionText, location) in notamSections {
+            let sectionNotams = parseNotamSection(sectionText, location: location)
+            notams.append(contentsOf: sectionNotams)
+        }
+
+        // Deduplicate by NOTAM ID
+        var seenIds = Set<String>()
+        var uniqueNotams: [Notam] = []
+        for notam in notams {
+            if !seenIds.contains(notam.id) {
+                seenIds.insert(notam.id)
+                uniqueNotams.append(notam)
+            }
+        }
+
+        return uniqueNotams
+    }
+
+    /// Find NOTAM sections in the briefing text.
+    ///
+    /// - Returns: Array of (sectionText, location) tuples
+    private func findNotamSections(in text: String) -> [(String, String)] {
+        var sections: [(String, String)] = []
+
+        // Pattern 1: "LFPG NOTAMs" or "NOTAMs for LFPG"
+        let pattern1 = try! NSRegularExpression(
+            pattern: #"(?:([A-Z]{4})\s+NOTAMs?|NOTAMs?\s+(?:for\s+)?([A-Z]{4}))\s*[:\n](.+?)(?=(?:[A-Z]{4}\s+NOTAMs?|NOTAMs?\s+(?:for\s+)?[A-Z]{4}|\z))"#,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        )
+
+        for match in pattern1.matches(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ) {
+            var location: String?
+            if match.range(at: 1).location != NSNotFound,
+               let locRange = Range(match.range(at: 1), in: text) {
+                location = String(text[locRange]).uppercased()
+            } else if match.range(at: 2).location != NSNotFound,
+                      let locRange = Range(match.range(at: 2), in: text) {
+                location = String(text[locRange]).uppercased()
+            }
+
+            if let loc = location,
+               let sectionRange = Range(match.range(at: 3), in: text) {
+                let sectionText = String(text[sectionRange])
+                sections.append((sectionText, loc))
+            }
+        }
+
+        // Pattern 2: Section headers with ICAO
+        let pattern2 = try! NSRegularExpression(
+            pattern: #"^\s*([A-Z]{4})\s*$\s*\n((?:(?![A-Z]{4}\s*$).)+)"#,
+            options: [.anchorsMatchLines, .dotMatchesLineSeparators]
+        )
+
+        let notamContentPattern = try! NSRegularExpression(
+            pattern: #"[A-Z]\d{4}/\d{2}|NOTAM"#,
+            options: [.caseInsensitive]
+        )
+
+        for match in pattern2.matches(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ) {
+            if let locRange = Range(match.range(at: 1), in: text),
+               let sectionRange = Range(match.range(at: 2), in: text) {
+                let location = String(text[locRange]).uppercased()
+                let sectionText = String(text[sectionRange])
+
+                // Only add if contains NOTAM-like content
+                if notamContentPattern.firstMatch(
+                    in: sectionText,
+                    range: NSRange(sectionText.startIndex..., in: sectionText)
+                ) != nil {
+                    sections.append((sectionText, location))
+                }
+            }
+        }
+
+        // Pattern 3: FDC NOTAMs section
+        let fdcPattern = try! NSRegularExpression(
+            pattern: #"FDC\s+NOTAMs?\s*[:\n](.+?)(?=\n\n[A-Z]|\z)"#,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        )
+
+        if let match = fdcPattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+           let sectionRange = Range(match.range(at: 1), in: text) {
+            sections.append((String(text[sectionRange]), "FDC"))
+        }
+
+        // If no sections found, try to find NOTAMs in the entire text
+        if sections.isEmpty {
+            let idPattern = try! NSRegularExpression(
+                pattern: #"[A-Z]\d{4}/\d{2}"#,
+                options: []
+            )
+            if idPattern.firstMatch(
+                in: text,
+                range: NSRange(text.startIndex..., in: text)
+            ) != nil {
+                sections.append((text, "UNKNOWN"))
+            }
+        }
+
+        return sections
+    }
+
+    /// Parse NOTAMs from a section of text.
+    private func parseNotamSection(_ sectionText: String, location: String) -> [Notam] {
+        var notams: [Notam] = []
+
+        // Split section into individual NOTAMs
+        let notamChunks = splitNotamSection(sectionText)
+
+        for chunk in notamChunks {
+            if var notam = NotamParser.parse(chunk, source: "foreflight") {
+                // Use section location if NOTAM location is unknown
+                if notam.location == "ZZZZ" && location != "UNKNOWN" {
+                    notam = Notam(
+                        id: notam.id,
+                        location: location,
+                        rawText: notam.rawText,
+                        message: notam.message,
+                        series: notam.series,
+                        number: notam.number,
+                        year: notam.year,
+                        fir: notam.fir,
+                        affectedLocations: notam.affectedLocations.isEmpty ? [location] : notam.affectedLocations,
+                        qCode: notam.qCode,
+                        trafficType: notam.trafficType,
+                        purpose: notam.purpose,
+                        scope: notam.scope,
+                        lowerLimit: notam.lowerLimit,
+                        upperLimit: notam.upperLimit,
+                        radiusNm: notam.radiusNm,
+                        coordinates: notam.coordinate.map { [$0.latitude, $0.longitude] },
+                        category: notam.category,
+                        subcategory: notam.subcategory,
+                        qCodeInfo: notam.qCodeInfo,
+                        effectiveFrom: notam.effectiveFrom,
+                        effectiveTo: notam.effectiveTo,
+                        isPermanent: notam.isPermanent,
+                        scheduleText: notam.scheduleText,
+                        source: notam.source,
+                        parsedAt: notam.parsedAt,
+                        parseConfidence: notam.parseConfidence,
+                        primaryCategory: notam.primaryCategory,
+                        customCategories: notam.customCategories,
+                        customTags: notam.customTags
+                    )
+                }
+                notams.append(notam)
+            }
+        }
+
+        return notams
+    }
+
+    /// Split a NOTAM section into individual NOTAM texts.
+    ///
+    /// Only splits on NOTAM IDs that start a new NOTAM (followed by NOTAM[NRC]),
+    /// not on IDs that appear as references (after NOTAMR/NOTAMC).
+    private func splitNotamSection(_ sectionText: String) -> [String] {
+        // Pattern for NOTAM ID at start of a new NOTAM
+        // Must be followed by NOTAM[NRC] (with possible space)
+        let startPattern = try! NSRegularExpression(
+            pattern: #"([A-Z]\d{4}/\d{2})\s*NOTAM[NRC]"#,
+            options: []
+        )
+        let matches = startPattern.matches(
+            in: sectionText,
+            range: NSRange(sectionText.startIndex..., in: sectionText)
+        )
+
+        if !matches.isEmpty {
+            var chunks: [String] = []
+            for (i, match) in matches.enumerated() {
+                guard let startRange = Range(match.range, in: sectionText) else { continue }
+                let start = startRange.lowerBound
+
+                let end: String.Index
+                if i + 1 < matches.count,
+                   let nextRange = Range(matches[i + 1].range, in: sectionText) {
+                    end = nextRange.lowerBound
+                } else {
+                    end = sectionText.endIndex
+                }
+
+                let chunk = String(sectionText[start..<end])
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if !chunk.isEmpty {
+                    chunks.append(chunk)
+                }
+            }
+            if !chunks.isEmpty {
+                return chunks
+            }
+        }
+
+        // Fallback: try the simple ID pattern if no NOTAM[NRC] markers found
+        let idPattern = try! NSRegularExpression(
+            pattern: #"[A-Z]\d{4}/\d{2}"#,
+            options: []
+        )
+        let idMatches = idPattern.matches(
+            in: sectionText,
+            range: NSRange(sectionText.startIndex..., in: sectionText)
+        )
+
+        if !idMatches.isEmpty {
+            // Filter out IDs that appear after NOTAMR/NOTAMC (references)
+            let notamRefPattern = try! NSRegularExpression(
+                pattern: #"NOTAM[RC]\s*$"#,
+                options: []
+            )
+
+            var validStarts: [NSTextCheckingResult] = []
+            for match in idMatches {
+                // Check what comes before this ID
+                let prefixStart = max(0, match.range.location - 10)
+                let prefixLength = match.range.location - prefixStart
+                let prefixRange = NSRange(location: prefixStart, length: prefixLength)
+
+                if let prefixStringRange = Range(prefixRange, in: sectionText) {
+                    let prefix = String(sectionText[prefixStringRange])
+                    if notamRefPattern.firstMatch(
+                        in: prefix,
+                        range: NSRange(prefix.startIndex..., in: prefix)
+                    ) == nil {
+                        validStarts.append(match)
+                    }
+                } else {
+                    validStarts.append(match)
+                }
+            }
+
+            if !validStarts.isEmpty {
+                var chunks: [String] = []
+                for (i, match) in validStarts.enumerated() {
+                    guard let startRange = Range(match.range, in: sectionText) else { continue }
+                    let start = startRange.lowerBound
+
+                    let end: String.Index
+                    if i + 1 < validStarts.count,
+                       let nextRange = Range(validStarts[i + 1].range, in: sectionText) {
+                        end = nextRange.lowerBound
+                    } else {
+                        end = sectionText.endIndex
+                    }
+
+                    let chunk = String(sectionText[start..<end])
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !chunk.isEmpty {
+                        chunks.append(chunk)
+                    }
+                }
+                if !chunks.isEmpty {
+                    return chunks
+                }
+            }
+        }
+
+        // Fallback: try splitting on double newline
+        let parts = sectionText.components(separatedBy: "\n\n")
+        var chunks: [String] = []
+        for part in parts {
+            let trimmed = part.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty && trimmed.count > 20 {
+                chunks.append(trimmed)
+            }
+        }
+
+        // If still nothing, return whole section
+        if chunks.isEmpty {
+            let trimmed = sectionText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                chunks = [trimmed]
+            }
+        }
+
+        return chunks
+    }
+}

--- a/Sources/RZFlight/Briefing/Notam.swift
+++ b/Sources/RZFlight/Briefing/Notam.swift
@@ -317,6 +317,75 @@ public struct Notam: Codable, Sendable {
 
 // MARK: - Protocol Conformances
 
+// MARK: - Memberwise Initializer
+
+extension Notam {
+    /// Create a NOTAM with all fields specified
+    public init(
+        id: String,
+        location: String,
+        rawText: String = "",
+        message: String = "",
+        series: String? = nil,
+        number: Int? = nil,
+        year: Int? = nil,
+        fir: String? = nil,
+        affectedLocations: [String] = [],
+        qCode: String? = nil,
+        trafficType: String? = nil,
+        purpose: String? = nil,
+        scope: String? = nil,
+        lowerLimit: Int? = nil,
+        upperLimit: Int? = nil,
+        radiusNm: Double? = nil,
+        coordinates: [Double]? = nil,
+        category: NotamCategory? = nil,
+        subcategory: String? = nil,
+        qCodeInfo: QCodeInfo? = nil,
+        effectiveFrom: Date? = nil,
+        effectiveTo: Date? = nil,
+        isPermanent: Bool = false,
+        scheduleText: String? = nil,
+        source: String? = nil,
+        parsedAt: Date = Date(),
+        parseConfidence: Double = 1.0,
+        primaryCategory: String? = nil,
+        customCategories: [String] = [],
+        customTags: [String] = []
+    ) {
+        self.id = id
+        self.location = location
+        self.rawText = rawText
+        self.message = message
+        self.series = series
+        self.number = number
+        self.year = year
+        self.fir = fir
+        self.affectedLocations = affectedLocations
+        self.qCode = qCode
+        self.trafficType = trafficType
+        self.purpose = purpose
+        self.scope = scope
+        self.lowerLimit = lowerLimit
+        self.upperLimit = upperLimit
+        self.radiusNm = radiusNm
+        self.coordinates = coordinates
+        self.category = category
+        self.subcategory = subcategory
+        self.qCodeInfo = qCodeInfo
+        self.effectiveFrom = effectiveFrom
+        self.effectiveTo = effectiveTo
+        self.isPermanent = isPermanent
+        self.scheduleText = scheduleText
+        self.source = source
+        self.parsedAt = parsedAt
+        self.parseConfidence = parseConfidence
+        self.primaryCategory = primaryCategory
+        self.customCategories = customCategories
+        self.customTags = customTags
+    }
+}
+
 extension Notam: Hashable, Equatable, Identifiable {
     public static func == (lhs: Notam, rhs: Notam) -> Bool {
         return lhs.id == rhs.id && lhs.location == rhs.location

--- a/Sources/RZFlight/Briefing/NotamParser.swift
+++ b/Sources/RZFlight/Briefing/NotamParser.swift
@@ -1,0 +1,641 @@
+//
+//  NotamParser.swift
+//  RZFlight
+//
+//  Native Swift parser for ICAO NOTAM format.
+//  Port of Python euro_aip.briefing.parsers.notam_parser
+//
+
+import Foundation
+
+/// Parser for ICAO NOTAM format.
+///
+/// Parses NOTAMs from text, extracting structured fields including:
+/// - NOTAM ID and series
+/// - Q-line (FIR, code, traffic, purpose, scope, limits, coordinates)
+/// - A-line (location)
+/// - B/C lines (effective times)
+/// - D-line (schedule)
+/// - E-line (message)
+/// - F/G lines (altitude limits)
+///
+/// Example:
+/// ```swift
+/// let notam = NotamParser.parse("""
+///     A1234/24 NOTAMN
+///     Q) LFFF/QMRLC/IV/NBO/A/000/999/4901N00225E005
+///     A) LFPG B) 2401150800 C) 2401152000
+///     E) RWY 09L/27R CLSD DUE TO MAINTENANCE
+/// """)
+/// ```
+public enum NotamParser {
+
+    // MARK: - Regex Patterns
+
+    /// Pattern for NOTAM ID: A1234/24
+    private static let notamIdPattern = try! NSRegularExpression(
+        pattern: #"([A-Z])(\d{4})/(\d{2})"#,
+        options: [.caseInsensitive]
+    )
+
+    /// Full Q-line pattern: FIR/QCODE/TRAFFIC/PURPOSE/SCOPE/LOWER/UPPER/COORDS[RADIUS]
+    /// Handles occasional whitespace before slashes
+    private static let qLinePattern = try! NSRegularExpression(
+        pattern: #"Q\)\s*([A-Z]{4})\s*/Q([A-Z]{2,5})\s*/([IVK]+)\s*/([NBOMK]+)\s*/([AEW]+)\s*/(\d{3})\s*/(\d{3})\s*/(\d{4}[NS]\d{5}[EW])(\d{3})?"#,
+        options: [.caseInsensitive]
+    )
+
+    /// Simple Q-line pattern for abbreviated formats
+    private static let qLineSimplePattern = try! NSRegularExpression(
+        pattern: #"Q\)\s*([A-Z]{4})/Q([A-Z]{2,5})"#,
+        options: [.caseInsensitive]
+    )
+
+    /// Coordinate pattern: DDMMN/S DDDMME/W
+    private static let coordPattern = try! NSRegularExpression(
+        pattern: #"(\d{2})(\d{2})([NS])(\d{3})(\d{2})([EW])"#,
+        options: [.caseInsensitive]
+    )
+
+    /// Q-code to category mapping
+    private static let qCodeCategories: [String: NotamCategory] = [
+        "MR": .runway,
+        "MX": .movementArea,
+        "MA": .movementArea,
+        "LR": .lighting,
+        "LL": .lighting,
+        "LX": .lighting,
+        "NA": .navigation,
+        "NV": .navigation,
+        "ND": .navigation,
+        "NI": .navigation,
+        "NL": .navigation,
+        "NM": .navigation,
+        "NB": .navigation,
+        "CO": .communication,
+        "FA": .airspace,
+        "AR": .airspace,
+        "AH": .airspace,
+        "AL": .airspace,
+        "AT": .airspace,
+        "AX": .airspace,
+        "RD": .airspace,
+        "RT": .airspace,
+        "OB": .obstacle,
+        "OL": .obstacle,
+        "PI": .procedure,
+        "PA": .procedure,
+        "PD": .procedure,
+        "PS": .procedure,
+        "PT": .procedure,
+        "SE": .services,
+        "SA": .services,
+        "SN": .services,
+        "SV": .services,
+        "WA": .warning,
+        "WE": .warning,
+        "WM": .warning,
+        "WP": .warning,
+        "WU": .warning,
+        "WV": .warning,
+        "WZ": .warning,
+    ]
+
+    // MARK: - Public Interface
+
+    /// Parse a single NOTAM from text.
+    ///
+    /// - Parameters:
+    ///   - text: Raw NOTAM text
+    ///   - source: Optional source identifier
+    /// - Returns: Parsed Notam object or nil if parsing fails
+    public static func parse(_ text: String, source: String? = nil) -> Notam? {
+        let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+
+        // Extract NOTAM ID
+        let (notamId, series, number, year) = parseNotamId(text)
+        let finalId = notamId ?? "X\(String(format: "%04d", abs(text.hashValue) % 10000))/00"
+
+        // Parse Q-line
+        let qData = parseQLine(text)
+
+        // Parse location (A-line)
+        var location = parseLocation(text)
+        if location == nil {
+            location = qData.fir
+        }
+        let finalLocation = location ?? "ZZZZ"
+
+        // Parse effective times
+        let (effectiveFrom, effectiveTo) = parseEffectiveTimes(text)
+
+        // Check if permanent
+        let isPermanent = checkIsPermanent(text, effectiveTo: effectiveTo)
+
+        // Parse schedule
+        let scheduleText = parseSchedule(text)
+
+        // Parse message (E-line)
+        let message = parseMessage(text)
+
+        // Parse altitude limits
+        let (lowerLimit, upperLimit) = parseAltitudeLimits(text, qData: qData)
+
+        // Determine category from Q-code
+        let category = determineCategory(qData.qCode)
+
+        return Notam(
+            id: finalId,
+            location: finalLocation,
+            rawText: text,
+            message: message,
+            series: series,
+            number: number,
+            year: year,
+            fir: qData.fir,
+            affectedLocations: finalLocation != "ZZZZ" ? [finalLocation] : [],
+            qCode: qData.qCode,
+            trafficType: qData.trafficType,
+            purpose: qData.purpose,
+            scope: qData.scope,
+            lowerLimit: lowerLimit,
+            upperLimit: upperLimit,
+            radiusNm: qData.radiusNm,
+            coordinates: qData.coordinates,
+            category: category,
+            subcategory: nil,
+            qCodeInfo: nil,
+            effectiveFrom: effectiveFrom,
+            effectiveTo: effectiveTo,
+            isPermanent: isPermanent,
+            scheduleText: scheduleText,
+            source: source,
+            parsedAt: Date(),
+            parseConfidence: 1.0,
+            primaryCategory: nil,
+            customCategories: [],
+            customTags: []
+        )
+    }
+
+    /// Parse multiple NOTAMs from a text block.
+    ///
+    /// - Parameters:
+    ///   - text: Text containing multiple NOTAMs
+    ///   - source: Optional source identifier
+    /// - Returns: List of parsed Notam objects
+    public static func parseMany(_ text: String, source: String? = nil) -> [Notam] {
+        let chunks = splitNotams(text)
+        return chunks.compactMap { parse($0, source: source) }
+    }
+
+    // MARK: - Private Parsing Methods
+
+    private static func parseNotamId(_ text: String) -> (String?, String?, Int?, Int?) {
+        guard let match = notamIdPattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ) else {
+            return (nil, nil, nil, nil)
+        }
+
+        guard let seriesRange = Range(match.range(at: 1), in: text),
+              let numberRange = Range(match.range(at: 2), in: text),
+              let yearRange = Range(match.range(at: 3), in: text) else {
+            return (nil, nil, nil, nil)
+        }
+
+        let series = String(text[seriesRange]).uppercased()
+        let number = Int(text[numberRange])!
+        let year = Int(text[yearRange])!
+        let notamId = "\(series)\(String(format: "%04d", number))/\(String(format: "%02d", year))"
+
+        return (notamId, series, number, year)
+    }
+
+    private struct QLineData {
+        var fir: String?
+        var qCode: String?
+        var trafficType: String?
+        var purpose: String?
+        var scope: String?
+        var lowerFL: Int?
+        var upperFL: Int?
+        var coordinates: [Double]?
+        var radiusNm: Double?
+    }
+
+    private static func parseQLine(_ text: String) -> QLineData {
+        var result = QLineData()
+
+        // Try full Q-line pattern
+        if let match = qLinePattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ) {
+            if let firRange = Range(match.range(at: 1), in: text) {
+                result.fir = String(text[firRange]).uppercased()
+            }
+            if let qCodeRange = Range(match.range(at: 2), in: text) {
+                result.qCode = "Q" + String(text[qCodeRange]).uppercased()
+            }
+            if let trafficRange = Range(match.range(at: 3), in: text) {
+                result.trafficType = String(text[trafficRange]).uppercased()
+            }
+            if let purposeRange = Range(match.range(at: 4), in: text) {
+                result.purpose = String(text[purposeRange]).uppercased()
+            }
+            if let scopeRange = Range(match.range(at: 5), in: text) {
+                result.scope = String(text[scopeRange]).uppercased()
+            }
+            if let lowerRange = Range(match.range(at: 6), in: text) {
+                result.lowerFL = Int(text[lowerRange])
+            }
+            if let upperRange = Range(match.range(at: 7), in: text) {
+                result.upperFL = Int(text[upperRange])
+            }
+            if let coordsRange = Range(match.range(at: 8), in: text) {
+                result.coordinates = parseCoordinates(String(text[coordsRange]))
+            }
+            if match.range(at: 9).location != NSNotFound,
+               let radiusRange = Range(match.range(at: 9), in: text) {
+                result.radiusNm = Double(text[radiusRange])
+            }
+
+            return result
+        }
+
+        // Try simple Q-line pattern
+        if let match = qLineSimplePattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ) {
+            if let firRange = Range(match.range(at: 1), in: text) {
+                result.fir = String(text[firRange]).uppercased()
+            }
+            if let qCodeRange = Range(match.range(at: 2), in: text) {
+                result.qCode = "Q" + String(text[qCodeRange]).uppercased()
+            }
+        }
+
+        return result
+    }
+
+    private static func parseCoordinates(_ coordsStr: String) -> [Double]? {
+        guard let match = coordPattern.firstMatch(
+            in: coordsStr,
+            range: NSRange(coordsStr.startIndex..., in: coordsStr)
+        ) else {
+            return nil
+        }
+
+        guard let latDegRange = Range(match.range(at: 1), in: coordsStr),
+              let latMinRange = Range(match.range(at: 2), in: coordsStr),
+              let latDirRange = Range(match.range(at: 3), in: coordsStr),
+              let lonDegRange = Range(match.range(at: 4), in: coordsStr),
+              let lonMinRange = Range(match.range(at: 5), in: coordsStr),
+              let lonDirRange = Range(match.range(at: 6), in: coordsStr) else {
+            return nil
+        }
+
+        let latDeg = Double(coordsStr[latDegRange])!
+        let latMin = Double(coordsStr[latMinRange])!
+        let latDir = String(coordsStr[latDirRange]).uppercased()
+        let lonDeg = Double(coordsStr[lonDegRange])!
+        let lonMin = Double(coordsStr[lonMinRange])!
+        let lonDir = String(coordsStr[lonDirRange]).uppercased()
+
+        var lat = latDeg + latMin / 60.0
+        if latDir == "S" {
+            lat = -lat
+        }
+
+        var lon = lonDeg + lonMin / 60.0
+        if lonDir == "W" {
+            lon = -lon
+        }
+
+        return [lat, lon]
+    }
+
+    private static func parseLocation(_ text: String) -> String? {
+        let pattern = try! NSRegularExpression(
+            pattern: #"A\)\s*([A-Z]{4})"#,
+            options: [.caseInsensitive]
+        )
+
+        guard let match = pattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+              let locationRange = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+
+        return String(text[locationRange]).uppercased()
+    }
+
+    private static func parseEffectiveTimes(_ text: String) -> (Date?, Date?) {
+        var effectiveFrom: Date?
+        var effectiveTo: Date?
+
+        // B) line - effective from
+        let bPattern = try! NSRegularExpression(
+            pattern: #"B\)\s*(\d{10})"#,
+            options: []
+        )
+        if let match = bPattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+           let dateRange = Range(match.range(at: 1), in: text) {
+            effectiveFrom = parseNotamDateTime(String(text[dateRange]))
+        }
+
+        // C) line - effective to
+        let cPattern = try! NSRegularExpression(
+            pattern: #"C\)\s*(\d{10}|PERM|UFN)"#,
+            options: [.caseInsensitive]
+        )
+        if let match = cPattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+           let valueRange = Range(match.range(at: 1), in: text) {
+            let value = String(text[valueRange]).uppercased()
+            if value != "PERM" && value != "UFN" {
+                effectiveTo = parseNotamDateTime(value)
+            }
+        }
+
+        return (effectiveFrom, effectiveTo)
+    }
+
+    private static func parseNotamDateTime(_ dtStr: String) -> Date? {
+        guard dtStr.count == 10 else { return nil }
+
+        let yearStr = String(dtStr.prefix(2))
+        let monthStr = String(dtStr.dropFirst(2).prefix(2))
+        let dayStr = String(dtStr.dropFirst(4).prefix(2))
+        let hourStr = String(dtStr.dropFirst(6).prefix(2))
+        let minuteStr = String(dtStr.dropFirst(8).prefix(2))
+
+        guard let year = Int(yearStr),
+              let month = Int(monthStr),
+              let day = Int(dayStr),
+              let hour = Int(hourStr),
+              let minute = Int(minuteStr) else {
+            return nil
+        }
+
+        var components = DateComponents()
+        components.year = 2000 + year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        components.timeZone = TimeZone(identifier: "UTC")
+
+        return Calendar(identifier: .gregorian).date(from: components)
+    }
+
+    private static func checkIsPermanent(_ text: String, effectiveTo: Date?) -> Bool {
+        if effectiveTo == nil {
+            // Check for PERM or UFN indicators
+            let permPattern = try! NSRegularExpression(
+                pattern: #"\b(PERM|UFN)\b"#,
+                options: [.caseInsensitive]
+            )
+            if permPattern.firstMatch(
+                in: text,
+                range: NSRange(text.startIndex..., in: text)
+            ) != nil {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func parseSchedule(_ text: String) -> String? {
+        let pattern = try! NSRegularExpression(
+            pattern: #"D\)\s*(.+?)(?=\n[A-G]\)|$)"#,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        )
+
+        guard let match = pattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+              let scheduleRange = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+
+        let schedule = String(text[scheduleRange])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+
+        return schedule.isEmpty ? nil : schedule
+    }
+
+    private static func parseMessage(_ text: String) -> String {
+        // Look for E) line
+        let pattern = try! NSRegularExpression(
+            pattern: #"E\)\s*(.+?)(?=\n[FG]\)|$)"#,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        )
+
+        if let match = pattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+           let messageRange = Range(match.range(at: 1), in: text) {
+            return String(text[messageRange])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        }
+
+        // Fallback: try to extract message after NOTAM ID
+        let idPattern = try! NSRegularExpression(
+            pattern: #"^[A-Z]\d{4}/\d{2}"#,
+            options: [.anchorsMatchLines]
+        )
+
+        let lines = text.components(separatedBy: "\n")
+        for (i, line) in lines.enumerated() {
+            if idPattern.firstMatch(
+                in: line,
+                range: NSRange(line.startIndex..., in: line)
+            ) != nil {
+                // Found NOTAM ID line, message is likely after
+                var remaining = lines.dropFirst(i + 1).joined(separator: "\n")
+                // Remove Q), A), B), C) lines
+                let cleanPattern = try! NSRegularExpression(
+                    pattern: #"[QABCD]\)[^\n]*"#,
+                    options: []
+                )
+                remaining = cleanPattern.stringByReplacingMatches(
+                    in: remaining,
+                    range: NSRange(remaining.startIndex..., in: remaining),
+                    withTemplate: ""
+                )
+                let cleaned = remaining
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+                if !cleaned.isEmpty {
+                    return cleaned
+                }
+            }
+        }
+
+        return ""
+    }
+
+    private static func parseAltitudeLimits(
+        _ text: String,
+        qData: QLineData
+    ) -> (Int?, Int?) {
+        var lowerLimit: Int?
+        var upperLimit: Int?
+
+        // Try Q-line flight levels first (convert to feet)
+        if let lowerFL = qData.lowerFL {
+            lowerLimit = lowerFL * 100
+        }
+        if let upperFL = qData.upperFL {
+            upperLimit = upperFL * 100
+        }
+
+        // F) line - lower limit
+        let fPattern = try! NSRegularExpression(
+            pattern: #"F\)\s*(SFC|GND|FL\s*(\d+)|(\d+)\s*(FT|M)?)"#,
+            options: [.caseInsensitive]
+        )
+        if let match = fPattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+           let fullRange = Range(match.range(at: 1), in: text) {
+            let fullMatch = String(text[fullRange]).uppercased()
+            if fullMatch == "SFC" || fullMatch == "GND" {
+                lowerLimit = 0
+            } else if fullMatch.hasPrefix("FL") {
+                if match.range(at: 2).location != NSNotFound,
+                   let flRange = Range(match.range(at: 2), in: text),
+                   let fl = Int(text[flRange]) {
+                    lowerLimit = fl * 100
+                }
+            } else if match.range(at: 3).location != NSNotFound,
+                      let valueRange = Range(match.range(at: 3), in: text),
+                      let value = Int(text[valueRange]) {
+                var unit = ""
+                if match.range(at: 4).location != NSNotFound,
+                   let unitRange = Range(match.range(at: 4), in: text) {
+                    unit = String(text[unitRange]).uppercased()
+                }
+                if unit == "M" {
+                    lowerLimit = Int(Double(value) * 3.28084)
+                } else {
+                    lowerLimit = value
+                }
+            }
+        }
+
+        // G) line - upper limit
+        let gPattern = try! NSRegularExpression(
+            pattern: #"G\)\s*(UNL|FL\s*(\d+)|(\d+)\s*(FT|M)?)"#,
+            options: [.caseInsensitive]
+        )
+        if let match = gPattern.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        ),
+           let fullRange = Range(match.range(at: 1), in: text) {
+            let fullMatch = String(text[fullRange]).uppercased()
+            if fullMatch == "UNL" {
+                upperLimit = 99999
+            } else if fullMatch.hasPrefix("FL") {
+                if match.range(at: 2).location != NSNotFound,
+                   let flRange = Range(match.range(at: 2), in: text),
+                   let fl = Int(text[flRange]) {
+                    upperLimit = fl * 100
+                }
+            } else if match.range(at: 3).location != NSNotFound,
+                      let valueRange = Range(match.range(at: 3), in: text),
+                      let value = Int(text[valueRange]) {
+                var unit = ""
+                if match.range(at: 4).location != NSNotFound,
+                   let unitRange = Range(match.range(at: 4), in: text) {
+                    unit = String(text[unitRange]).uppercased()
+                }
+                if unit == "M" {
+                    upperLimit = Int(Double(value) * 3.28084)
+                } else {
+                    upperLimit = value
+                }
+            }
+        }
+
+        return (lowerLimit, upperLimit)
+    }
+
+    private static func determineCategory(_ qCode: String?) -> NotamCategory? {
+        guard var code = qCode?.uppercased() else { return nil }
+
+        // Remove 'Q' prefix if present
+        if code.hasPrefix("Q") {
+            code = String(code.dropFirst())
+        }
+
+        // Check first 2 letters
+        let prefix = String(code.prefix(2))
+        return qCodeCategories[prefix] ?? .other
+    }
+
+    private static func splitNotams(_ text: String) -> [String] {
+        // Find all NOTAM ID positions
+        let idPattern = try! NSRegularExpression(
+            pattern: #"[A-Z]\d{4}/\d{2}"#,
+            options: []
+        )
+        let matches = idPattern.matches(
+            in: text,
+            range: NSRange(text.startIndex..., in: text)
+        )
+
+        if matches.isEmpty {
+            // No NOTAM IDs found - try splitting on double newlines
+            let parts = text.components(separatedBy: "\n\n")
+            let chunks = parts
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty && $0.count > 20 }
+            if !chunks.isEmpty {
+                return chunks
+            }
+            // Fallback: treat entire text as one NOTAM
+            return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? [] : [text]
+        }
+
+        // Extract text from each NOTAM ID to the next
+        var chunks: [String] = []
+        for (i, match) in matches.enumerated() {
+            guard let startRange = Range(match.range, in: text) else { continue }
+            let start = startRange.lowerBound
+
+            let end: String.Index
+            if i + 1 < matches.count,
+               let nextRange = Range(matches[i + 1].range, in: text) {
+                end = nextRange.lowerBound
+            } else {
+                end = text.endIndex
+            }
+
+            let chunk = String(text[start..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !chunk.isEmpty {
+                chunks.append(chunk)
+            }
+        }
+
+        return chunks
+    }
+}

--- a/Sources/RZFlight/Briefing/Route.swift
+++ b/Sources/RZFlight/Briefing/Route.swift
@@ -191,6 +191,41 @@ public struct Route: Codable, Sendable {
     }
 }
 
+// MARK: - Memberwise Initializer
+
+extension Route {
+    /// Create a Route with all fields specified
+    public init(
+        departure: String,
+        destination: String,
+        alternates: [String] = [],
+        waypoints: [String] = [],
+        departureCoords: [Double]? = nil,
+        destinationCoords: [Double]? = nil,
+        alternateCoords: [String: [Double]]? = nil,
+        waypointCoords: [RoutePoint] = [],
+        aircraftType: String? = nil,
+        departureTime: Date? = nil,
+        arrivalTime: Date? = nil,
+        flightLevel: Int? = nil,
+        cruiseAltitudeFt: Int? = nil
+    ) {
+        self.departure = departure
+        self.destination = destination
+        self.alternates = alternates
+        self.waypoints = waypoints
+        self.departureCoords = departureCoords
+        self.destinationCoords = destinationCoords
+        self.alternateCoords = alternateCoords
+        self.waypointCoords = waypointCoords
+        self.aircraftType = aircraftType
+        self.departureTime = departureTime
+        self.arrivalTime = arrivalTime
+        self.flightLevel = flightLevel
+        self.cruiseAltitudeFt = cruiseAltitudeFt
+    }
+}
+
 // MARK: - Protocol Conformances
 
 extension Route: CustomStringConvertible {
@@ -201,4 +236,14 @@ extension Route: CustomStringConvertible {
 
 extension RoutePoint: Hashable, Equatable, Identifiable {
     public var id: String { name }
+}
+
+extension RoutePoint {
+    /// Create a RoutePoint with all fields specified
+    public init(name: String, latitude: Double, longitude: Double, pointType: String = "waypoint") {
+        self.name = name
+        self.latitude = latitude
+        self.longitude = longitude
+        self.pointType = pointType
+    }
 }

--- a/designs/native_pdf_parsing.md
+++ b/designs/native_pdf_parsing.md
@@ -1,0 +1,247 @@
+# Native iOS PDF Parsing
+
+> Swift-native parsing for ForeFlight PDF briefings using PDFKit
+
+## Intent
+
+Provide native iOS parsing capability that:
+- Eliminates API dependency for PDF briefing parsing
+- Works offline on iOS devices
+- Produces the same `Briefing` model as Python parsing
+- Mirrors Python `ForeFlightSource` logic for consistency
+
+**What this enables**: Fully offline PDF briefing parsing on iOS without server round-trips.
+
+## Architecture
+
+```
+Sources/RZFlight/Briefing/
+├── Briefing.swift           # Container model (existing)
+├── Notam.swift              # NOTAM model (existing, extended)
+├── NotamCategory.swift      # Category enum (existing)
+├── Route.swift              # Route model (existing, extended)
+├── Notam+Queries.swift      # Filtering extensions (existing)
+├── NotamParser.swift        # NEW: NOTAM text parsing
+└── ForeFlightParser.swift   # NEW: PDF extraction + parsing
+```
+
+**Data flow:**
+```
+iOS App                           Swift Package
+───────                           ─────────────
+PDF file/data
+     │
+     ▼
+ForeFlightParser.parse(url:)
+     │
+     ├── PDFKit text extraction
+     │   ├── Two-column layout handling
+     │   └── Page-by-page processing
+     │
+     ├── Route extraction
+     │   ├── Departure/Destination patterns
+     │   ├── Alternates extraction
+     │   └── Waypoints extraction
+     │
+     └── NOTAM extraction
+         ├── Section finding
+         ├── NOTAM splitting
+         └── NotamParser.parse() per NOTAM
+                  │
+                  ▼
+              Briefing model
+```
+
+## Usage Examples
+
+### Parse from File URL
+```swift
+let parser = ForeFlightParser()
+let briefing = try parser.parse(url: pdfFileURL)
+
+// Access route
+print(briefing.route?.departure)  // "LFPG"
+print(briefing.route?.destination)  // "EGLL"
+
+// Filter NOTAMs
+let runwayNotams = briefing.notams
+    .forAirport("LFPG")
+    .runwayRelated()
+```
+
+### Parse from Raw Data
+```swift
+// From downloaded PDF data
+let pdfData: Data = ...
+let briefing = try parser.parse(data: pdfData)
+
+// From pre-extracted text (if text extraction done elsewhere)
+let text: String = ...
+let briefing = parser.parse(text: text)
+```
+
+### Error Handling
+```swift
+do {
+    let briefing = try parser.parse(url: url)
+} catch ForeFlightParser.ParserError.fileNotFound(let url) {
+    print("File not found: \(url)")
+} catch ForeFlightParser.ParserError.invalidPDF {
+    print("Invalid PDF format")
+} catch ForeFlightParser.ParserError.textExtractionFailed {
+    print("Could not extract text from PDF")
+} catch ForeFlightParser.ParserError.noContent {
+    print("PDF appears empty")
+}
+```
+
+## Key Components
+
+### ForeFlightParser
+
+Main entry point for PDF parsing.
+
+| Method | Description |
+|--------|-------------|
+| `parse(url:)` | Parse PDF from file URL |
+| `parse(data:)` | Parse PDF from raw Data |
+| `parse(text:)` | Parse from pre-extracted text |
+
+**PDF Text Extraction:**
+- Uses `PDFKit.PDFDocument` for PDF handling
+- Detects landscape pages (common in ForeFlight) as two-column
+- Uses `PDFPage.selection(for:)` to extract columns separately
+- Concatenates left column then right column for proper reading order
+
+### NotamParser
+
+Static parser for individual NOTAM text blocks.
+
+| Method | Description |
+|--------|-------------|
+| `parse(_:source:)` | Parse single NOTAM text |
+| `parseMany(_:source:)` | Parse text containing multiple NOTAMs |
+
+**Extracted Fields:**
+- NOTAM ID, series, number, year
+- Q-line: FIR, Q-code, traffic type, purpose, scope, altitude limits, coordinates, radius
+- A-line: Location
+- B/C lines: Effective times
+- D-line: Schedule
+- E-line: Message
+- F/G lines: Altitude limits (override Q-line if present)
+
+## Implementation Details
+
+### Two-Column Layout Handling
+
+ForeFlight briefings often use landscape two-column layouts for NOTAM pages:
+
+```swift
+// Detect landscape orientation
+if page.bounds.width > page.bounds.height {
+    // Extract left column first
+    let leftRect = CGRect(x: 0, y: 0, width: width/2, height: height)
+    let leftText = page.selection(for: leftRect)?.string ?? ""
+
+    // Then right column
+    let rightRect = CGRect(x: width/2, y: 0, width: width/2, height: height)
+    let rightText = page.selection(for: rightRect)?.string ?? ""
+
+    return leftText + "\n\n" + rightText
+}
+```
+
+### NOTAM Section Detection
+
+Multiple patterns to find NOTAM sections:
+
+1. **Explicit headers**: `"LFPG NOTAMs"` or `"NOTAMs for LFPG"`
+2. **Standalone ICAO headers**: `"LFPG"` on its own line followed by NOTAM content
+3. **FDC NOTAMs**: `"FDC NOTAMs"` section
+4. **Fallback**: Any text containing NOTAM ID patterns
+
+### NOTAM Splitting
+
+Smart splitting that avoids breaking on referenced NOTAMs:
+
+```swift
+// Only split on IDs that START a new NOTAM (followed by NOTAM[NRC])
+// Not on referenced NOTAMs like "NOTAMR E1234/25"
+let startPattern = #"([A-Z]\d{4}/\d{2})\s*NOTAM[NRC]"#
+```
+
+### Q-Code Category Mapping
+
+Maps Q-code prefixes to `NotamCategory`:
+
+| Prefix | Category |
+|--------|----------|
+| MR | runway |
+| MX, MA | movementArea |
+| LR, LL, LX | lighting |
+| NA, NV, ND, NI, NL, NM, NB | navigation |
+| CO | communication |
+| FA, AR, AH, AL, AT, AX, RD, RT | airspace |
+| OB, OL | obstacle |
+| PI, PA, PD, PS, PT | procedure |
+| SE, SA, SN, SV | services |
+| WA, WE, WM, WP, WU, WV, WZ | warning |
+
+## Comparison with Python Implementation
+
+| Aspect | Python | Swift |
+|--------|--------|-------|
+| PDF Library | pdfplumber | PDFKit |
+| Regex | re module | NSRegularExpression |
+| Two-column | page.crop() | PDFPage.selection(for:) |
+| Output | Briefing dataclass | Briefing struct |
+| JSON | to_json() / from_json() | Codable |
+
+**Functional Parity**: The Swift implementation mirrors the Python logic for:
+- Route extraction patterns
+- NOTAM section finding
+- NOTAM splitting (including NOTAMR/C reference handling)
+- Q-line parsing
+- Altitude limit parsing (F/G lines, FL conversion)
+- Datetime parsing (YYMMDDHHMM format)
+
+## Key Choices
+
+| Decision | Rationale |
+|----------|-----------|
+| PDFKit over Core Graphics | Higher-level API, simpler text extraction |
+| NSRegularExpression | Foundation native, consistent with Python re |
+| Static NotamParser | Matches Python class methods pattern |
+| Memberwise initializers added | Enable direct construction without JSON |
+| Sendable conformance | Thread-safe for async operations |
+
+## Patterns
+
+- **Two-pass extraction**: First extract text (PDFKit), then parse (regex)
+- **Fallback patterns**: Multiple regex patterns tried in order of reliability
+- **Section-based parsing**: Find sections first, then parse NOTAMs within
+- **Deduplication**: Remove duplicate NOTAMs by ID
+
+## Gotchas
+
+- **PDFKit text quality**: Depends on how PDF was generated; ForeFlight PDFs are digitally created so work well
+- **Column detection**: Simple width > height check; may need refinement for unusual layouts
+- **Coordinate system**: PDF coordinates are bottom-left origin; PDFKit handles this
+- **Optional fields**: Many NOTAM fields may be nil; all made optional
+
+## Testing
+
+Recommended tests:
+1. Parse sample ForeFlight PDF, verify route extraction
+2. Parse PDF with two-column layout, verify text ordering
+3. Parse various NOTAM formats (full Q-line, abbreviated, etc.)
+4. Verify deduplication of repeated NOTAMs
+5. Compare output with Python parser on same input
+
+## References
+
+- Python source: `euro_aip/euro_aip/briefing/sources/foreflight.py`
+- Python NOTAM parser: `euro_aip/euro_aip/briefing/parsers/notam_parser.py`
+- Swift models: `Sources/RZFlight/Briefing/`
+- PDFKit docs: [Apple Developer](https://developer.apple.com/documentation/pdfkit)


### PR DESCRIPTION
Implement native Swift parsing for ForeFlight PDF briefings,
eliminating the need for API calls to parse PDFs on iOS devices.

- Add ForeFlightParser using PDFKit for text extraction
- Add NotamParser ported from Python notam_parser.py
- Handle two-column landscape layouts in ForeFlight PDFs
- Add memberwise initializers to Briefing, Notam, Route, RoutePoint
- Add design documentation for native PDF parsing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables offline, Swift-native parsing of ForeFlight PDF briefings and structured NOTAM extraction.
> 
> - Add `ForeFlightParser` using PDFKit for text extraction, two-column handling, route parsing, and NOTAM section processing
> - Add `NotamParser` to parse ICAO NOTAM text (Q-line, A/B/C/D/E/F/G lines, categories, times, limits)
> - Extend models with memberwise initializers: `Briefing`, `Notam`, `Route`, `RoutePoint`
> - Include design doc `designs/native_pdf_parsing.md` outlining architecture and usage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb52973f65d0a3358838c8ffab1cf358bd78ddbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->