### PR TITLE
feat: add AutorouterNotamSource for NOTAM API fetching

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,37 @@
+Review target: $ARGUMENTS
+
+If $ARGUMENTS is a GitHub PR URL or repo/pull/number:
+- Use `gh` to fetch the PR diff and description
+- Focus review on changed lines only
+- Post the review as a PR comment using `gh pr comment`
+
+Otherwise:
+- Interpret $ARGUMENTS as a description of what to review
+- Use git log, git diff, or file reads as appropriate to 
+  find the relevant changes
+
+Then apply the standard review criteria:
+
+Before starting the review, read the following for context:
+- CLAUDE.md at the repo root for coding standards
+- Any design documents in /designs/ folder relevant to files being changed
+- use the designs documents for module intent and architecture
+
+Then perform a code review of the current PR focusing on:
+- Bugs and logic errors
+- CLAUDE.md violations
+- Deviations from the documented architecture/design intent from the designs documents
+- Swift/iOS best practices (memory management, concurrency)
+- TypeScript: type safety, avoid `any`, async/await correctness
+- Python: type hints, error handling, async patterns if applicable
+- Code and logic duplication, opportunity for optimisation and consolidation
+- Check for simplicity, maintainability and extensibility
+
+Do NOT flag:
+- Style issues not covered by CLAUDE.md
+- Minor suggestions or nits
+- Pre-existing issues not touched by this PR
+
+Be concise. High confidence issues only.
+
+If no issues found, post a brief approval comment.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,62 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          print_output: "true"
+          prompt: '/code-review https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_tools: |
+            Bash(git diff:*)
+            Bash(git log:*)
+            Bash(git show:*)
+            Bash(git status)
+            Bash(cat:*)
+            Bash(ls:*)
+            Bash(find:*)
+            Bash(grep:*)
+            Bash(head:*)
+            Bash(tail:*)
+            Read
+            Glob
+            Grep
+            mcp__github__pull_request_read
+            mcp__github__pull_request_review_write
+            mcp__github__add_reply_to_pull_request_comment
+            mcp__github__list_commits
+            mcp__github__get_file_contents
+            mcp__github__search_code
+            mcp__github__add_issue_comment
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,79 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          print_output: "true"
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          allowed_tools: |
+            Bash(git diff:*)
+            Bash(git log:*)
+            Bash(git show:*)
+            Bash(git status)
+            Bash(git fetch:*)
+            Bash(python:*)
+            Bash(pip:*)
+            Bash(npm:*)
+            Bash(npx:*)
+            Bash(cat:*)
+            Bash(ls:*)
+            Bash(find:*)
+            Bash(grep:*)
+            Bash(head:*)
+            Bash(tail:*)
+            Read
+            Edit
+            Write
+            Glob
+            Grep
+            mcp__github__create_pull_request
+            mcp__github__add_issue_comment
+            mcp__github__add_reply_to_pull_request_comment
+            mcp__github__create_branch
+            mcp__github__create_or_update_file
+            mcp__github__list_commits
+            mcp__github__list_pull_requests
+            mcp__github__pull_request_read
+            mcp__github__pull_request_review_write
+            mcp__github__search_code
+            mcp__github__get_file_contents
+            mcp__github__issue_read
+            mcp__github__issue_write
+            mcp__github__push_files
+

--- a/euro_aip/euro_aip/briefing/sources/__init__.py
+++ b/euro_aip/euro_aip/briefing/sources/__init__.py
@@ -2,5 +2,6 @@
 
 from euro_aip.briefing.sources.foreflight import ForeFlightSource
 from euro_aip.briefing.sources.avwx import AvWxSource
+from euro_aip.briefing.sources.autorouter_notam import AutorouterNotamSource
 
-__all__ = ['ForeFlightSource', 'AvWxSource']
+__all__ = ['ForeFlightSource', 'AvWxSource', 'AutorouterNotamSource']

--- a/euro_aip/euro_aip/briefing/sources/autorouter_notam.py
+++ b/euro_aip/euro_aip/briefing/sources/autorouter_notam.py
@@ -1,0 +1,222 @@
+"""Autorouter NOTAM API source.
+
+Fetches NOTAMs from the Autorouter API and converts them to Notam dataclass instances.
+Uses the same AutorouterCredentialManager as the AIP data source for OAuth2 authentication.
+
+API docs: https://www.autorouter.aero/wiki/api/notams/
+"""
+
+import json
+import logging
+import requests
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Any
+
+from euro_aip.briefing.models.notam import Notam, NotamCategory
+from euro_aip.utils.autorouter_credentials import AutorouterCredentialManager
+
+logger = logging.getLogger(__name__)
+
+# Maximum items per API request (API limit)
+_PAGE_LIMIT = 100
+# Maximum ICAOs per request to avoid URL length issues
+_ICAO_BATCH_SIZE = 20
+
+
+class AutorouterNotamSource:
+    """Fetches NOTAMs from the Autorouter API and converts to Notam models."""
+
+    def __init__(self, credential_manager: AutorouterCredentialManager):
+        self.credential_manager = credential_manager
+        self.base_url = "https://api.autorouter.aero/v1.0/notam"
+
+    def _get_headers(self) -> Dict[str, str]:
+        """Get headers with Bearer token for API requests."""
+        return {
+            "Authorization": f"Bearer {self.credential_manager.get_token()}",
+            "Accept": "application/json",
+        }
+
+    def fetch_notams(
+        self,
+        icaos: List[str],
+        start_validity: Optional[datetime] = None,
+        end_validity: Optional[datetime] = None,
+    ) -> List[Notam]:
+        """
+        Fetch NOTAMs for given ICAO airport/FIR codes.
+
+        Handles pagination (API limit of 100 per request) and deduplication
+        when the same NOTAM appears for multiple queried locations.
+
+        Args:
+            icaos: ICAO airport codes and/or FIR codes (e.g., ["LFPG", "EGTT"])
+            start_validity: Only return NOTAMs valid after this time
+            end_validity: Only return NOTAMs valid before this time
+
+        Returns:
+            Deduplicated list of Notam objects
+        """
+        if not icaos:
+            return []
+
+        start_epoch = int(start_validity.timestamp()) if start_validity else None
+        end_epoch = int(end_validity.timestamp()) if end_validity else None
+
+        all_notams: List[Notam] = []
+
+        # Batch ICAOs to avoid URL length issues
+        for i in range(0, len(icaos), _ICAO_BATCH_SIZE):
+            batch = icaos[i : i + _ICAO_BATCH_SIZE]
+            offset = 0
+            while True:
+                rows = self._fetch_page(batch, offset, _PAGE_LIMIT, start_epoch, end_epoch)
+                for row in rows:
+                    try:
+                        notam = self._row_to_notam(row)
+                        all_notams.append(notam)
+                    except Exception as e:
+                        logger.warning("Failed to convert NOTAM row: %s — %s", row.get("id", "?"), e)
+                if len(rows) < _PAGE_LIMIT:
+                    break
+                offset += _PAGE_LIMIT
+
+        # Deduplicate by NOTAM id
+        seen = set()
+        unique = []
+        for notam in all_notams:
+            if notam.id not in seen:
+                seen.add(notam.id)
+                unique.append(notam)
+
+        logger.info(
+            "Fetched %d NOTAMs (%d unique) for %d ICAO codes",
+            len(all_notams), len(unique), len(icaos),
+        )
+        return unique
+
+    def _fetch_page(
+        self,
+        icaos: List[str],
+        offset: int,
+        limit: int,
+        start_validity: Optional[int],
+        end_validity: Optional[int],
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch a single page of NOTAMs from the API.
+
+        Args:
+            icaos: ICAO codes for this batch
+            offset: Pagination offset
+            limit: Max results per page (API max: 100)
+            start_validity: Unix epoch seconds or None
+            end_validity: Unix epoch seconds or None
+
+        Returns:
+            List of raw NOTAM row dicts from the API
+        """
+        params: Dict[str, Any] = {
+            "itemas": json.dumps(icaos),
+            "offset": offset,
+            "limit": limit,
+        }
+        if start_validity is not None:
+            params["startvalidity"] = start_validity
+        if end_validity is not None:
+            params["endvalidity"] = end_validity
+
+        try:
+            response = requests.get(
+                self.base_url, headers=self._get_headers(), params=params
+            )
+            response.raise_for_status()
+            data = response.json()
+            rows = data.get("rows", [])
+            logger.debug(
+                "Fetched page: offset=%d, got %d rows (total=%s)",
+                offset, len(rows), data.get("total", "?"),
+            )
+            return rows
+        except requests.RequestException as e:
+            logger.error("Autorouter NOTAM API request failed: %s", e)
+            raise
+
+    @staticmethod
+    def _row_to_notam(row: Dict[str, Any]) -> Notam:
+        """
+        Convert an Autorouter NOTAM API row to a Notam dataclass.
+
+        API response fields:
+            code23, code45, endvalidity, fir, id, itema, iteme,
+            lat, lon, lower, upper, modified, nof, number,
+            purpose, scope, series, startvalidity, suppressed,
+            traffic, type, year
+        """
+        # Build NOTAM ID: series + number/year (e.g., "A1234/24")
+        series = row.get("series", "")
+        number = row.get("number", 0)
+        year = row.get("year", 0)
+        notam_id = f"{series}{number:04d}/{year % 100:02d}" if series else str(row.get("id", ""))
+
+        # Reconstruct Q-code from code23 + code45 (e.g., "MR" + "LC" → "QMRLC")
+        code23 = row.get("code23", "")
+        code45 = row.get("code45", "")
+        q_code = f"Q{code23}{code45}" if code23 and code45 else None
+
+        # Category from Q-code
+        category = NotamCategory.from_q_code(q_code) if q_code else None
+
+        # Coordinates
+        lat = row.get("lat")
+        lon = row.get("lon")
+        coordinates = (lat, lon) if lat is not None and lon is not None else None
+
+        # Validity times (unix epoch → datetime UTC)
+        start_epoch = row.get("startvalidity")
+        end_epoch = row.get("endvalidity")
+
+        effective_from = (
+            datetime.fromtimestamp(start_epoch, tz=timezone.utc)
+            if start_epoch
+            else None
+        )
+
+        # endvalidity of 0 or very large value typically means permanent
+        is_permanent = end_epoch is None or end_epoch == 0
+        effective_to = (
+            datetime.fromtimestamp(end_epoch, tz=timezone.utc)
+            if end_epoch and not is_permanent
+            else None
+        )
+
+        # Altitude limits: API returns flight levels, convert to feet
+        lower_fl = row.get("lower")
+        upper_fl = row.get("upper")
+        lower_limit = lower_fl * 100 if lower_fl is not None else None
+        upper_limit = upper_fl * 100 if upper_fl is not None else None
+
+        message = row.get("iteme", "")
+
+        return Notam(
+            id=notam_id,
+            location=row.get("itema", ""),
+            raw_text=message,
+            message=message,
+            series=series or None,
+            number=number or None,
+            year=year or None,
+            fir=row.get("fir"),
+            q_code=q_code,
+            traffic_type=row.get("traffic"),
+            purpose=row.get("purpose"),
+            scope=row.get("scope"),
+            lower_limit=lower_limit,
+            upper_limit=upper_limit,
+            coordinates=coordinates,
+            category=category,
+            effective_from=effective_from,
+            effective_to=effective_to,
+            is_permanent=is_permanent,
+            source="autorouter",
+        )

--- a/euro_aip/tests/briefing/test_autorouter_notam.py
+++ b/euro_aip/tests/briefing/test_autorouter_notam.py
@@ -1,0 +1,273 @@
+"""Tests for AutorouterNotamSource."""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+from euro_aip.briefing.sources.autorouter_notam import AutorouterNotamSource
+from euro_aip.briefing.models.notam import NotamCategory
+
+
+# Sample API response row matching the Autorouter NOTAM API format
+SAMPLE_ROW = {
+    "id": 123456,
+    "series": "A",
+    "number": 1234,
+    "year": 2024,
+    "fir": "LFFF",
+    "itema": "LFPG",
+    "iteme": "RWY 09L/27R CLSD DUE TO MAINTENANCE",
+    "code23": "MR",
+    "code45": "LC",
+    "traffic": "IV",
+    "purpose": "NBO",
+    "scope": "A",
+    "lower": 0,
+    "upper": 999,
+    "lat": 49.01,
+    "lon": 2.55,
+    "startvalidity": 1711929600,  # 2024-04-01 00:00:00 UTC
+    "endvalidity": 1711972800,    # 2024-04-01 12:00:00 UTC
+    "suppressed": False,
+    "type": "N",
+    "nof": "LFFA",
+    "modified": 1711900000,
+}
+
+SAMPLE_PERMANENT_ROW = {
+    "id": 789,
+    "series": "C",
+    "number": 42,
+    "year": 2024,
+    "fir": "EGTT",
+    "itema": "EGLL",
+    "iteme": "CRANE ERECTED AT 512800N 0001200W",
+    "code23": "OB",
+    "code45": "CE",
+    "traffic": "IV",
+    "purpose": "BO",
+    "scope": "W",
+    "lower": 0,
+    "upper": 20,
+    "lat": 51.47,
+    "lon": -0.20,
+    "startvalidity": 1711929600,
+    "endvalidity": 0,  # permanent
+    "suppressed": False,
+    "type": "N",
+    "nof": "EGFA",
+    "modified": 1711900000,
+}
+
+SAMPLE_NO_COORDS_ROW = {
+    "id": 456,
+    "series": "B",
+    "number": 99,
+    "year": 2024,
+    "fir": "EDGG",
+    "itema": "EDGG",
+    "iteme": "FIR FRANKFURT NOTAM TEXT",
+    "code23": "AF",
+    "code45": "AH",
+    "traffic": "I",
+    "purpose": "N",
+    "scope": "E",
+    "lower": 0,
+    "upper": 999,
+    "lat": None,
+    "lon": None,
+    "startvalidity": 1711929600,
+    "endvalidity": 1712016000,
+    "suppressed": False,
+    "type": "N",
+    "nof": "EDFA",
+    "modified": 1711900000,
+}
+
+
+class TestRowToNotam:
+    """Tests for _row_to_notam field mapping."""
+
+    def test_basic_field_mapping(self):
+        """Test that all fields are correctly mapped from API row."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_ROW)
+
+        assert notam.id == "A1234/24"
+        assert notam.location == "LFPG"
+        assert notam.fir == "LFFF"
+        assert notam.message == "RWY 09L/27R CLSD DUE TO MAINTENANCE"
+        assert notam.raw_text == notam.message
+        assert notam.series == "A"
+        assert notam.number == 1234
+        assert notam.year == 2024
+        assert notam.source == "autorouter"
+
+    def test_q_code_reconstruction(self):
+        """Test Q-code is reconstructed from code23 + code45."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_ROW)
+
+        assert notam.q_code == "QMRLC"
+        assert notam.category == NotamCategory.AGA_MOVEMENT
+
+    def test_q_line_fields(self):
+        """Test traffic, purpose, scope are mapped."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_ROW)
+
+        assert notam.traffic_type == "IV"
+        assert notam.purpose == "NBO"
+        assert notam.scope == "A"
+
+    def test_altitude_conversion(self):
+        """Test flight levels are converted to feet (FL * 100)."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_ROW)
+
+        assert notam.lower_limit == 0
+        assert notam.upper_limit == 99900  # FL999 * 100
+
+    def test_coordinates(self):
+        """Test coordinates are mapped as (lat, lon) tuple."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_ROW)
+
+        assert notam.coordinates == (49.01, 2.55)
+
+    def test_no_coordinates(self):
+        """Test missing coordinates result in None."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_NO_COORDS_ROW)
+
+        assert notam.coordinates is None
+
+    def test_validity_times(self):
+        """Test unix epoch times are converted to UTC datetimes."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_ROW)
+
+        assert notam.effective_from is not None
+        assert notam.effective_from.tzinfo == timezone.utc
+        assert notam.effective_from == datetime(2024, 4, 1, 0, 0, 0, tzinfo=timezone.utc)
+        assert notam.effective_to is not None
+        assert notam.effective_to == datetime(2024, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+        assert notam.is_permanent is False
+
+    def test_permanent_notam(self):
+        """Test endvalidity=0 is treated as permanent."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_PERMANENT_ROW)
+
+        assert notam.is_permanent is True
+        assert notam.effective_to is None
+
+    def test_obstacle_category(self):
+        """Test obstacle Q-code (OB) maps to OTHER_INFO category."""
+        notam = AutorouterNotamSource._row_to_notam(SAMPLE_PERMANENT_ROW)
+
+        assert notam.q_code == "QOBCE"
+        assert notam.category == NotamCategory.OTHER_INFO
+
+    def test_missing_q_code_fields(self):
+        """Test graceful handling when code23/code45 are empty."""
+        row = {**SAMPLE_ROW, "code23": "", "code45": ""}
+        notam = AutorouterNotamSource._row_to_notam(row)
+
+        assert notam.q_code is None
+        assert notam.category is None
+
+
+class TestFetchNotams:
+    """Tests for fetch_notams pagination and deduplication."""
+
+    def _make_source(self):
+        """Create a source with mock credentials."""
+        cred_mgr = MagicMock()
+        cred_mgr.get_token.return_value = "mock-token"
+        return AutorouterNotamSource(cred_mgr)
+
+    @patch("euro_aip.briefing.sources.autorouter_notam.requests.get")
+    def test_single_page(self, mock_get):
+        """Test fetching when all results fit in one page."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "total": 2,
+            "rows": [SAMPLE_ROW, SAMPLE_PERMANENT_ROW],
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        source = self._make_source()
+        notams = source.fetch_notams(["LFPG", "EGLL"])
+
+        assert len(notams) == 2
+        assert notams[0].id == "A1234/24"
+        assert notams[1].location == "EGLL"
+        mock_get.assert_called_once()
+
+    @patch("euro_aip.briefing.sources.autorouter_notam.requests.get")
+    def test_pagination(self, mock_get):
+        """Test automatic pagination when results exceed page limit."""
+        # First page: 100 items (triggers next page)
+        page1_rows = [{**SAMPLE_ROW, "number": i, "id": i} for i in range(100)]
+        # Second page: 50 items (done)
+        page2_rows = [{**SAMPLE_ROW, "number": i + 100, "id": i + 100} for i in range(50)]
+
+        mock_responses = [
+            MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={"total": 150, "rows": page1_rows}),
+                raise_for_status=MagicMock(),
+            ),
+            MagicMock(
+                status_code=200,
+                json=MagicMock(return_value={"total": 150, "rows": page2_rows}),
+                raise_for_status=MagicMock(),
+            ),
+        ]
+        mock_get.side_effect = mock_responses
+
+        source = self._make_source()
+        notams = source.fetch_notams(["LFPG"])
+
+        assert len(notams) == 150
+        assert mock_get.call_count == 2
+
+    @patch("euro_aip.briefing.sources.autorouter_notam.requests.get")
+    def test_deduplication(self, mock_get):
+        """Test that duplicate NOTAMs (same id) are removed."""
+        # Same NOTAM appearing for two different query codes
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "total": 2,
+            "rows": [SAMPLE_ROW, SAMPLE_ROW],  # duplicate
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        source = self._make_source()
+        notams = source.fetch_notams(["LFPG"])
+
+        assert len(notams) == 1
+
+    @patch("euro_aip.briefing.sources.autorouter_notam.requests.get")
+    def test_empty_icaos(self, mock_get):
+        """Test empty ICAO list returns empty result."""
+        source = self._make_source()
+        notams = source.fetch_notams([])
+
+        assert notams == []
+        mock_get.assert_not_called()
+
+    @patch("euro_aip.briefing.sources.autorouter_notam.requests.get")
+    def test_validity_time_params(self, mock_get):
+        """Test that validity time params are passed to API."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"total": 0, "rows": []}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        source = self._make_source()
+        start = datetime(2024, 4, 1, tzinfo=timezone.utc)
+        end = datetime(2024, 4, 2, tzinfo=timezone.utc)
+        source.fetch_notams(["LFPG"], start_validity=start, end_validity=end)
+
+        call_params = mock_get.call_args[1]["params"]
+        assert call_params["startvalidity"] == int(start.timestamp())
+        assert call_params["endvalidity"] == int(end.timestamp())


### PR DESCRIPTION
## Summary
- New `AutorouterNotamSource` class in `euro_aip.briefing.sources` that fetches NOTAMs from the Autorouter API and converts them to the existing `Notam` dataclass
- Handles pagination (100/page), ICAO batching (20/request), and deduplication
- Reuses `AutorouterCredentialManager` for OAuth2 authentication
- 15 unit tests covering field mapping, pagination, dedup, and edge cases

## Test plan
- [x] All 15 unit tests pass (`pytest tests/briefing/test_autorouter_notam.py`)
- [ ] Integration test with live Autorouter API credentials
- [ ] Verify field mapping produces valid `Notam` objects consumable by Swift `Briefing.load(from:)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)