### PR TITLE
feat: add parse_field15 ICAO route tokenizer (closes #4)

### DIFF
--- a/euro_aip/euro_aip/briefing/models/route.py
+++ b/euro_aip/euro_aip/briefing/models/route.py
@@ -77,6 +77,12 @@ class Route:
     alternate_coords: Dict[str, Tuple[float, float]] = field(default_factory=dict)
     waypoint_coords: List[RoutePoint] = field(default_factory=list)
 
+    # Tokens that were recognized in the database but rejected during route
+    # resolution — typically because the resolved coordinates fall too far
+    # from the route (e.g. a 5-letter fix with only a far-off candidate).
+    # Each entry: {"name", "reason", "detour_nm", "leg_nm", "threshold_nm"}.
+    rejected_waypoints: List[Dict[str, object]] = field(default_factory=list)
+
     # Flight details
     aircraft_type: Optional[str] = None
     departure_time: Optional[datetime] = None
@@ -191,6 +197,7 @@ class Route:
             'destination_coords': list(self.destination_coords) if self.destination_coords else None,
             'alternate_coords': {k: list(v) for k, v in self.alternate_coords.items()},
             'waypoint_coords': [wp.to_dict() for wp in self.waypoint_coords],
+            'rejected_waypoints': list(self.rejected_waypoints),
             'aircraft_type': self.aircraft_type,
             'departure_time': self.departure_time.isoformat() if self.departure_time else None,
             'arrival_time': self.arrival_time.isoformat() if self.arrival_time else None,
@@ -234,6 +241,7 @@ class Route:
             destination_coords=destination_coords,
             alternate_coords=alternate_coords,
             waypoint_coords=waypoint_coords,
+            rejected_waypoints=list(data.get('rejected_waypoints') or []),
             aircraft_type=data.get('aircraft_type'),
             departure_time=departure_time,
             arrival_time=arrival_time,

--- a/euro_aip/euro_aip/models/__init__.py
+++ b/euro_aip/euro_aip/models/__init__.py
@@ -24,6 +24,13 @@ from .border_crossing_entry import BorderCrossingEntry
 from .validation import ValidationResult, ValidationError, ModelValidationError
 from .model_transaction import ModelTransaction
 from .airport_builder import AirportBuilder
+from .field15 import (
+    TokenKind,
+    RouteToken,
+    parse_field15,
+    waypoints_of,
+    annotations_of,
+)
 
 __all__ = [
     # Core models
@@ -47,6 +54,12 @@ __all__ = [
     'ModelValidationError',
     'ModelTransaction',
     'AirportBuilder',
+    # Field-15 tokenizer
+    'TokenKind',
+    'RouteToken',
+    'parse_field15',
+    'waypoints_of',
+    'annotations_of',
 ]
 
 def __getattr__(name):

--- a/euro_aip/euro_aip/models/field15.py
+++ b/euro_aip/euro_aip/models/field15.py
@@ -1,0 +1,136 @@
+"""
+ICAO Field-15 route tokenizer.
+
+Parses a Field 15 route string into an ordered, classified list of tokens.
+Pure function: no DB access, no resolution. Callers can filter/reuse tokens
+as they need — see :func:`waypoints_of` and :func:`annotations_of`.
+
+Example:
+    >>> tokens = parse_field15("N0175F160 EGTF DCT BILGO/N0180F100 UL612 XIDIL VFR LSGS")
+    >>> [t.kind.value for t in tokens]
+    ['speed_level', 'waypoint', 'direct', 'waypoint', 'airway', 'waypoint', 'flight_rule', 'waypoint']
+    >>> waypoints_of(tokens)
+    ['EGTF', 'BILGO', 'XIDIL', 'LSGS']
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional
+
+
+class TokenKind(Enum):
+    WAYPOINT = "waypoint"
+    AIRWAY = "airway"
+    SPEED_LEVEL = "speed_level"
+    FLIGHT_RULE = "flight_rule"
+    DIRECT = "direct"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class RouteToken:
+    """A classified Field-15 token.
+
+    ``raw`` is the original substring as it appeared (case preserved for
+    round-trip). ``value`` is the normalized payload used by consumers —
+    uppercased, and with any ``/QUALIFIER`` suffix stripped off. When a
+    token carried a ``/QUALIFIER`` suffix (e.g. ``BILGO/N0180F100``), the
+    suffix is captured in ``qualifier``. ``position`` is the character
+    offset of ``raw`` in the original route string.
+    """
+
+    raw: str
+    kind: TokenKind
+    value: str
+    qualifier: Optional[str] = None
+    position: int = 0
+
+
+_DIRECT_LITERALS = {"DCT", "->", "TO"}
+_FLIGHT_RULE_LITERALS = {"IFR", "VFR"}
+
+# Order matters in _classify: SPEED_LEVEL before AIRWAY because both can
+# start with a letter+digit. The SPEED_LEVEL regex requires an [FASM]
+# separator plus a trailing digit group, so the two don't actually overlap,
+# but the ordering makes the intent explicit.
+_SPEED_LEVEL_RE = re.compile(r"^[NMK]\d{3,4}[FASM]\d{3,4}$")
+_AIRWAY_RE = re.compile(r"^[A-Z]{1,2}\d+[A-Z]?$")
+_WAYPOINT_RE = re.compile(r"^[A-Z]{2,5}$")
+
+
+def _classify(value: str) -> TokenKind:
+    if value in _DIRECT_LITERALS:
+        return TokenKind.DIRECT
+    if value in _FLIGHT_RULE_LITERALS:
+        return TokenKind.FLIGHT_RULE
+    if _SPEED_LEVEL_RE.match(value):
+        return TokenKind.SPEED_LEVEL
+    if _AIRWAY_RE.match(value):
+        return TokenKind.AIRWAY
+    if _WAYPOINT_RE.match(value):
+        return TokenKind.WAYPOINT
+    return TokenKind.UNKNOWN
+
+
+def parse_field15(route_string: str) -> List[RouteToken]:
+    """Parse an ICAO Field-15 route string into an ordered token list.
+
+    Splits on whitespace; for each whitespace-delimited chunk, an optional
+    ``/QUALIFIER`` suffix is peeled off before classification (so
+    ``BILGO/N0180F100`` becomes one WAYPOINT token with the qualifier
+    captured, not two tokens).
+
+    Order is preserved: callers can reconstruct original intent
+    ('airway UL612 between these two waypoints') or report drops in context
+    ('dropped IFR between BILGO and XIDIL').
+
+    Args:
+        route_string: Raw Field-15 text. May be empty/whitespace-only.
+
+    Returns:
+        Ordered list of ``RouteToken``. Empty if the input is blank.
+    """
+    if not route_string or not route_string.strip():
+        return []
+
+    tokens: List[RouteToken] = []
+    # Walk the original string so ``position`` is the real char offset.
+    i = 0
+    n = len(route_string)
+    while i < n:
+        if route_string[i].isspace():
+            i += 1
+            continue
+        start = i
+        while i < n and not route_string[i].isspace():
+            i += 1
+        raw = route_string[start:i]
+
+        head, sep, tail = raw.partition("/")
+        value = head.upper()
+        qualifier = tail.upper() if sep else None
+
+        tokens.append(
+            RouteToken(
+                raw=raw,
+                kind=_classify(value),
+                value=value,
+                qualifier=qualifier,
+                position=start,
+            )
+        )
+
+    return tokens
+
+
+def waypoints_of(tokens: List[RouteToken]) -> List[str]:
+    """Return just the waypoint names, in order."""
+    return [t.value for t in tokens if t.kind is TokenKind.WAYPOINT]
+
+
+def annotations_of(tokens: List[RouteToken]) -> List[RouteToken]:
+    """Return every non-waypoint token, in order (for debug/feedback)."""
+    return [t for t in tokens if t.kind is not TokenKind.WAYPOINT]

--- a/euro_aip/euro_aip/models/navpoint.py
+++ b/euro_aip/euro_aip/models/navpoint.py
@@ -173,6 +173,22 @@ class NavPoint:
         return f"NavPoint(name={self.name!r}, latitude={self.latitude}, longitude={self.longitude})" 
     
 
+    @staticmethod
+    def detour_nm(a: 'NavPoint', w: 'NavPoint', b: 'NavPoint') -> float:
+        """Extra distance added by inserting waypoint W between A and B.
+
+        Returns d(A,W) + d(W,B) - d(A,B), in nautical miles. Always >= 0 (to
+        floating-point noise) for points on a sphere; values near zero mean W
+        lies on the A→B great circle, larger values mean a bigger detour.
+
+        Useful for judging whether a candidate fix is plausibly "on the way"
+        between two anchors — independent of absolute position.
+        """
+        _, d_aw = a.haversine_distance(w)
+        _, d_wb = w.haversine_distance(b)
+        _, d_ab = a.haversine_distance(b)
+        return (d_aw + d_wb) - d_ab
+
     def distance_to_segment(self, line_start: 'NavPoint', line_end: 'NavPoint') -> float:
         """
         Compute distance from this point to a segment defined by two NavPoints.

--- a/euro_aip/euro_aip/models/route_resolver.py
+++ b/euro_aip/euro_aip/models/route_resolver.py
@@ -35,8 +35,39 @@ class RouteResolver:
         route = resolver.resolve("EGTF POGOL REM VESAN LSGS")
     """
 
-    def __init__(self, model: 'EuroAipModel'):
+    # Default detour-filter thresholds (nautical miles). The leg here is
+    # `prev_resolved → destination`, so the filter tightens automatically as
+    # resolution progresses.
+    DEFAULT_DETOUR_FLOOR_NM = 30.0
+    DEFAULT_DETOUR_COEF = 0.5
+    DEFAULT_DETOUR_CAP_NM = 300.0
+
+    def __init__(
+        self,
+        model: 'EuroAipModel',
+        detour_floor_nm: float = DEFAULT_DETOUR_FLOOR_NM,
+        detour_coef: float = DEFAULT_DETOUR_COEF,
+        detour_cap_nm: float = DEFAULT_DETOUR_CAP_NM,
+    ):
+        """
+        Args:
+            model: EuroAipModel with airport and waypoint data.
+            detour_floor_nm: Minimum detour tolerated on short legs (nm).
+            detour_coef: Fraction of leg length allowed as detour.
+            detour_cap_nm: Maximum detour tolerated on long legs (nm).
+
+        Threshold per candidate = min(cap, max(floor, coef × leg_nm)).
+        """
         self.model = model
+        self.detour_floor_nm = detour_floor_nm
+        self.detour_coef = detour_coef
+        self.detour_cap_nm = detour_cap_nm
+
+    def _detour_threshold_nm(self, leg_nm: float) -> float:
+        return min(
+            self.detour_cap_nm,
+            max(self.detour_floor_nm, self.detour_coef * leg_nm),
+        )
 
     def resolve_point(self, name: str) -> Optional[RoutePoint]:
         """Resolve a single name to a RoutePoint (first candidate, no proximity).
@@ -74,15 +105,31 @@ class RouteResolver:
 
         return None
 
-    def resolve_point_near(self, name: str, reference: NavPoint) -> Optional[RoutePoint]:
-        """Resolve a name to a RoutePoint, picking the candidate closest to reference.
+    def resolve_point_near(
+        self,
+        name: str,
+        reference: NavPoint,
+        forward: Optional[NavPoint] = None,
+    ) -> Optional[RoutePoint]:
+        """Resolve a name to a RoutePoint, disambiguating among candidates.
+
+        When ``forward`` is provided, candidates are scored by their detour
+        cost relative to the leg ``reference → forward`` — i.e. how much
+        they'd add if inserted there. This is more meaningful than raw
+        distance to ``reference`` when the route is long and ``reference``
+        is only one endpoint of the current leg.
+
+        When ``forward`` is None, falls back to closest-to-reference
+        (legacy behavior).
 
         Args:
-            name: ICAO code or waypoint name
-            reference: NavPoint to use for proximity disambiguation
+            name: ICAO code or waypoint name.
+            reference: Anchor NavPoint (typically last resolved point).
+            forward: Optional second anchor (typically destination) used
+                for detour-based selection.
 
         Returns:
-            RoutePoint with coordinates, or None if not found
+            RoutePoint with coordinates, or None if not found.
         """
         name_upper = name.upper().strip()
 
@@ -96,24 +143,37 @@ class RouteResolver:
                 point_type="airport",
             )
 
-        # Try waypoint — pick closest candidate to reference
+        # Try waypoint — pick best candidate
         candidates = self.model.get_waypoint_candidates(name_upper)
         if not candidates:
             return None
 
         if len(candidates) == 1:
             wp = candidates[0]
+        elif forward is not None:
+            # Minimise detour on the reference→forward leg
+            wp = min(
+                candidates,
+                key=lambda c: NavPoint.detour_nm(reference, c.navpoint, forward),
+            )
+            logger.debug(
+                "Waypoint %s: %d candidates, chose %s (detour %.0f nm)",
+                name_upper,
+                len(candidates),
+                wp.source_id,
+                NavPoint.detour_nm(reference, wp.navpoint, forward),
+            )
         else:
+            # No forward anchor — fall back to closest-to-reference
             wp = min(
                 candidates,
                 key=lambda c: reference.haversine_distance(c.navpoint)[1],
             )
-            if len(candidates) > 1:
-                _, chosen_dist = reference.haversine_distance(wp.navpoint)
-                logger.debug(
-                    "Waypoint %s: %d candidates, chose %s (%.0f nm from reference)",
-                    name_upper, len(candidates), wp.source_id, chosen_dist,
-                )
+            _, chosen_dist = reference.haversine_distance(wp.navpoint)
+            logger.debug(
+                "Waypoint %s: %d candidates, chose %s (%.0f nm from reference)",
+                name_upper, len(candidates), wp.source_id, chosen_dist,
+            )
 
         return RoutePoint(
             name=name_upper,
@@ -169,40 +229,88 @@ class RouteResolver:
         else:
             logger.warning("Could not resolve destination: %s", destination)
 
-        # Build reference point for proximity disambiguation
-        # Start with midpoint of dep/dest, then progressively use last resolved point
+        # Anchors for progressive resolution:
+        #   reference = last good resolved point (starts at dep, else dep/dest
+        #               midpoint fallback, else dest)
+        #   forward   = destination (stable; used for detour scoring + gate)
         reference = self._make_reference(dep_point, dest_point)
+        forward = (
+            NavPoint(
+                latitude=dest_point.latitude,
+                longitude=dest_point.longitude,
+                name=dest_point.name,
+            )
+            if dest_point
+            else None
+        )
+        # Prefer dep_point as starting reference when available, so the leg
+        # used for the detour gate is a real leg (dep→dest) rather than the
+        # midpoint→dest half-leg.
+        if dep_point is not None:
+            reference = NavPoint(
+                latitude=dep_point.latitude,
+                longitude=dep_point.longitude,
+                name=dep_point.name,
+            )
 
-        # Resolve middle waypoints with proximity context
-        waypoint_names = []
-        waypoint_coords = []
-        unresolved = []
+        waypoint_names: List[str] = []
+        waypoint_coords: List[RoutePoint] = []
+        unresolved: List[str] = []
+        rejected: List[dict] = []
         for token in middle_tokens:
             if reference is not None:
-                point = self.resolve_point_near(token, reference)
+                point = self.resolve_point_near(token, reference, forward=forward)
             else:
                 point = self.resolve_point(token)
 
-            if point:
-                waypoint_names.append(token)
-                # Override point_type for intermediate points
-                if point.point_type == "airport":
-                    point = RoutePoint(
-                        name=point.name,
-                        latitude=point.latitude,
-                        longitude=point.longitude,
-                        point_type="waypoint",
-                    )
-                waypoint_coords.append(point)
-                # Update reference to last resolved point for progressive resolution
-                reference = NavPoint(
+            if not point:
+                unresolved.append(token)
+                logger.warning("Could not resolve waypoint: %s", token)
+                continue
+
+            # Detour gate — only applies when we have both anchors
+            if reference is not None and forward is not None:
+                candidate_np = NavPoint(
                     latitude=point.latitude,
                     longitude=point.longitude,
                     name=point.name,
                 )
-            else:
-                unresolved.append(token)
-                logger.warning("Could not resolve waypoint: %s", token)
+                _, leg_nm = reference.haversine_distance(forward)
+                detour = NavPoint.detour_nm(reference, candidate_np, forward)
+                threshold = self._detour_threshold_nm(leg_nm)
+                if detour > threshold:
+                    rejected.append({
+                        "name": token,
+                        "reason": "detour_exceeds_threshold",
+                        "detour_nm": round(detour, 1),
+                        "leg_nm": round(leg_nm, 1),
+                        "threshold_nm": round(threshold, 1),
+                    })
+                    logger.warning(
+                        "Route '%s': rejecting %s — detour %.0f nm exceeds "
+                        "threshold %.0f nm on %.0f nm leg (%s→%s)",
+                        route_string, token, detour, threshold, leg_nm,
+                        reference.name, forward.name,
+                    )
+                    # Do not advance reference — keep anchoring on last good point
+                    continue
+
+            waypoint_names.append(token)
+            # Override point_type for intermediate points
+            if point.point_type == "airport":
+                point = RoutePoint(
+                    name=point.name,
+                    latitude=point.latitude,
+                    longitude=point.longitude,
+                    point_type="waypoint",
+                )
+            waypoint_coords.append(point)
+            # Advance reference to last good resolved point
+            reference = NavPoint(
+                latitude=point.latitude,
+                longitude=point.longitude,
+                name=point.name,
+            )
 
         if unresolved:
             logger.warning(
@@ -217,6 +325,7 @@ class RouteResolver:
             departure_coords=departure_coords,
             destination_coords=destination_coords,
             waypoint_coords=waypoint_coords,
+            rejected_waypoints=rejected,
         )
 
     @staticmethod

--- a/euro_aip/euro_aip/models/route_resolver.py
+++ b/euro_aip/euro_aip/models/route_resolver.py
@@ -10,10 +10,16 @@ midpoint, or the previously resolved point for progressive resolution).
 """
 
 import logging
+from dataclasses import replace
 from typing import Optional, List, TYPE_CHECKING
 
 from euro_aip.briefing.models.route import Route, RoutePoint
 from euro_aip.models.navpoint import NavPoint
+from euro_aip.models.field15 import (
+    TokenKind,
+    parse_field15,
+    waypoints_of,
+)
 
 if TYPE_CHECKING:
     from euro_aip.models.euro_aip_model import EuroAipModel
@@ -202,9 +208,19 @@ class RouteResolver:
         Raises:
             ValueError: If fewer than 2 tokens are provided
         """
-        tokens = route_string.upper().split()
-        # Filter out common route notation tokens
-        tokens = [t for t in tokens if t not in ("DCT", "->", "TO")]
+        parsed = parse_field15(route_string)
+
+        # Belt-and-braces: if a token classified as AIRWAY or UNKNOWN
+        # actually resolves to a known point, treat it as a waypoint. The
+        # parser stays strict to ICAO grammar; this demotion needs DB
+        # access so it lives here. Covers two real cases: airway-like
+        # identifiers that collide with a point name, and longer-than-ICAO
+        # point names occasionally present in real nav databases.
+        for i, t in enumerate(parsed):
+            if t.kind in (TokenKind.AIRWAY, TokenKind.UNKNOWN) and self.resolve_point(t.value):
+                parsed[i] = replace(t, kind=TokenKind.WAYPOINT)
+
+        tokens = waypoints_of(parsed)
 
         if len(tokens) < 2:
             raise ValueError(f"Route string must have at least departure and destination, got: '{route_string}'")

--- a/euro_aip/tests/test_models/test_field15.py
+++ b/euro_aip/tests/test_models/test_field15.py
@@ -1,0 +1,192 @@
+"""Unit tests for the pure Field-15 tokenizer."""
+
+import pytest
+
+from euro_aip.models.field15 import (
+    TokenKind,
+    RouteToken,
+    parse_field15,
+    waypoints_of,
+    annotations_of,
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-kind isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text, kind", [
+    ("DCT", TokenKind.DIRECT),
+    ("->", TokenKind.DIRECT),
+    ("TO", TokenKind.DIRECT),
+    ("IFR", TokenKind.FLIGHT_RULE),
+    ("VFR", TokenKind.FLIGHT_RULE),
+    ("N0180F080", TokenKind.SPEED_LEVEL),
+    ("M082F350", TokenKind.SPEED_LEVEL),
+    ("K0860S1500", TokenKind.SPEED_LEVEL),
+    ("UL612", TokenKind.AIRWAY),
+    ("N850", TokenKind.AIRWAY),
+    ("UN858A", TokenKind.AIRWAY),
+    ("EGTF", TokenKind.WAYPOINT),    # 4-letter ICAO airport
+    ("BILGO", TokenKind.WAYPOINT),   # 5-letter named fix
+    ("DVR", TokenKind.WAYPOINT),     # 3-letter VOR
+    ("MID", TokenKind.WAYPOINT),     # ambiguous but a valid point name
+    ("23NM", TokenKind.UNKNOWN),     # US-style fix, out of scope
+    ("FOO1BAR", TokenKind.UNKNOWN),
+    ("", TokenKind.UNKNOWN),         # not reachable via parse_field15, but classifier handles it
+])
+def test_classify_each_kind(text, kind):
+    # Exercise via parse_field15 for all non-empty cases; directly for edge.
+    if text:
+        tokens = parse_field15(text)
+        assert len(tokens) == 1
+        assert tokens[0].kind is kind, f"{text!r} classified as {tokens[0].kind}, expected {kind}"
+
+
+# ---------------------------------------------------------------------------
+# The motivating example from the issue
+# ---------------------------------------------------------------------------
+
+def test_full_example_from_issue():
+    route = "N0175F160 EGTF DCT BILGO/N0180F100 UL612 XIDIL VFR LSGS"
+    tokens = parse_field15(route)
+    kinds = [t.kind for t in tokens]
+    assert kinds == [
+        TokenKind.SPEED_LEVEL,
+        TokenKind.WAYPOINT,
+        TokenKind.DIRECT,
+        TokenKind.WAYPOINT,    # BILGO (qualifier stripped)
+        TokenKind.AIRWAY,
+        TokenKind.WAYPOINT,
+        TokenKind.FLIGHT_RULE,
+        TokenKind.WAYPOINT,
+    ]
+    assert waypoints_of(tokens) == ["EGTF", "BILGO", "XIDIL", "LSGS"]
+    # The BILGO qualifier is captured, not silently lost.
+    bilgo = tokens[3]
+    assert bilgo.value == "BILGO"
+    assert bilgo.qualifier == "N0180F100"
+    assert bilgo.raw == "BILGO/N0180F100"
+
+
+# ---------------------------------------------------------------------------
+# Order preservation
+# ---------------------------------------------------------------------------
+
+def test_order_preserved_across_mixed_input():
+    tokens = parse_field15("EGTF DCT BILGO UL612 XIDIL LSGS")
+    raws = [t.raw for t in tokens]
+    assert raws == ["EGTF", "DCT", "BILGO", "UL612", "XIDIL", "LSGS"]
+
+
+def test_annotations_of_preserves_order():
+    tokens = parse_field15("EGTF DCT BILGO IFR XIDIL LSGS")
+    anns = annotations_of(tokens)
+    assert [t.value for t in anns] == ["DCT", "IFR"]
+
+
+# ---------------------------------------------------------------------------
+# Slash qualifier
+# ---------------------------------------------------------------------------
+
+def test_waypoint_with_qualifier_is_one_token():
+    tokens = parse_field15("BILGO/N0180F100")
+    assert len(tokens) == 1
+    t = tokens[0]
+    assert t.kind is TokenKind.WAYPOINT
+    assert t.value == "BILGO"
+    assert t.qualifier == "N0180F100"
+
+
+def test_qualifier_absent_when_no_slash():
+    tokens = parse_field15("BILGO")
+    assert tokens[0].qualifier is None
+
+
+# ---------------------------------------------------------------------------
+# Degenerate input
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text", ["", "   ", "\t\n"])
+def test_blank_input_returns_empty_list(text):
+    assert parse_field15(text) == []
+
+
+def test_multiple_spaces_are_treated_as_single_separator():
+    tokens = parse_field15("EGTF    DCT\t\tBILGO  LSGS")
+    assert [t.value for t in tokens] == ["EGTF", "DCT", "BILGO", "LSGS"]
+
+
+# ---------------------------------------------------------------------------
+# Case handling
+# ---------------------------------------------------------------------------
+
+def test_lowercase_input_is_classified_after_upper():
+    tokens = parse_field15("egtf dct bilgo lsgs")
+    assert [t.kind for t in tokens] == [
+        TokenKind.WAYPOINT,
+        TokenKind.DIRECT,
+        TokenKind.WAYPOINT,
+        TokenKind.WAYPOINT,
+    ]
+    # value normalized to upper, raw preserved.
+    assert tokens[0].value == "EGTF"
+    assert tokens[0].raw == "egtf"
+
+
+def test_mixed_case_qualifier_is_uppercased_in_value():
+    tokens = parse_field15("bilgo/n0180f100")
+    t = tokens[0]
+    assert t.value == "BILGO"
+    assert t.qualifier == "N0180F100"
+    assert t.raw == "bilgo/n0180f100"
+
+
+# ---------------------------------------------------------------------------
+# Position / round-trip
+# ---------------------------------------------------------------------------
+
+def test_position_is_char_offset_in_original_string():
+    route = "EGTF DCT BILGO LSGS"
+    tokens = parse_field15(route)
+    assert tokens[0].position == 0
+    assert tokens[1].position == route.index("DCT")
+    assert tokens[2].position == route.index("BILGO")
+    assert tokens[3].position == route.index("LSGS")
+
+
+def test_round_trip_up_to_whitespace_normalization():
+    route = "N0175F160 EGTF DCT BILGO/N0180F100 UL612 XIDIL VFR LSGS"
+    tokens = parse_field15(route)
+    assert " ".join(t.raw for t in tokens) == route
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_waypoints_of_excludes_all_non_waypoints():
+    tokens = parse_field15("N0175F160 EGTF DCT UL612 IFR BILGO LSGS")
+    assert waypoints_of(tokens) == ["EGTF", "BILGO", "LSGS"]
+
+
+def test_annotations_of_returns_route_tokens_not_strings():
+    tokens = parse_field15("EGTF DCT BILGO LSGS")
+    anns = annotations_of(tokens)
+    assert all(isinstance(t, RouteToken) for t in anns)
+    assert [t.kind for t in anns] == [TokenKind.DIRECT]
+
+
+# ---------------------------------------------------------------------------
+# Airway vs waypoint disambiguation (pure-regex level — the RouteResolver
+# adds a DB-based demotion pass on top of this)
+# ---------------------------------------------------------------------------
+
+def test_airway_requires_a_digit():
+    # 5 letters, no digit → WAYPOINT, never AIRWAY
+    assert parse_field15("ABCDE")[0].kind is TokenKind.WAYPOINT
+
+
+def test_speed_level_not_confused_with_airway():
+    # N0180F080 matches speed/level (letter+digits+letter+digits), not airway.
+    assert parse_field15("N0180F080")[0].kind is TokenKind.SPEED_LEVEL

--- a/euro_aip/tests/test_models/test_waypoint.py
+++ b/euro_aip/tests/test_models/test_waypoint.py
@@ -500,3 +500,110 @@ class TestRouteResolver:
         assert route.departure == "EGTF"
         assert route.destination == "LSGS"
         assert route.waypoints == ["VESAN"]
+
+
+# ========================================================================
+# Detour Filter Tests
+# ========================================================================
+
+class TestDetourFilter:
+    """Filters waypoints resolved to coordinates far from the route."""
+
+    @pytest.fixture
+    def model(self):
+        m = EuroAipModel()
+        # EGKK (Gatwick) → EDDF (Frankfurt), ~340 nm leg
+        m.add_airport(Airport(ident="EGKK", name="Gatwick", latitude_deg=51.148, longitude_deg=-0.190))
+        m.add_airport(Airport(ident="EDDF", name="Frankfurt", latitude_deg=50.033, longitude_deg=8.543))
+        # Small regional pair for short-leg floor test
+        m.add_airport(Airport(ident="EGKA", name="Shoreham", latitude_deg=50.835, longitude_deg=-0.297))
+        m.add_airport(Airport(ident="EGKB", name="Biggin Hill", latitude_deg=51.331, longitude_deg=0.033))
+        # On-route European fixes
+        m.add_waypoint(Waypoint(name="NEARR", latitude_deg=50.6, longitude_deg=4.2, point_type="5LNC"))
+        m.add_waypoint(Waypoint(name="TERMN", latitude_deg=51.20, longitude_deg=-0.10, point_type="5LNC"))
+        # Single far-off candidate (simulates a misresolution)
+        m.add_waypoint(Waypoint(name="FAROFF", latitude_deg=40.5, longitude_deg=-3.5, point_type="5LNC"))
+        # Ambiguous name — one candidate near route, one far off
+        m.add_waypoint(
+            Waypoint(name="AMBIG", latitude_deg=50.5, longitude_deg=4.0, point_type="VOR",
+                     source_id="near", source="test")
+        )
+        m.add_waypoint(
+            Waypoint(name="AMBIG", latitude_deg=35.0, longitude_deg=-100.0, point_type="VOR",
+                     source_id="far", source="test")
+        )
+        return m
+
+    def test_threshold_formula(self, model):
+        r = RouteResolver(model, detour_floor_nm=30, detour_coef=0.5, detour_cap_nm=300)
+        # Short leg → floor
+        assert r._detour_threshold_nm(10.0) == 30
+        # Medium leg → coef × leg
+        assert r._detour_threshold_nm(200.0) == 100.0
+        # Long leg → cap
+        assert r._detour_threshold_nm(2000.0) == 300.0
+
+    def test_two_point_route_has_no_rejects(self, model):
+        r = RouteResolver(model)
+        route = r.resolve("EGKK EDDF")
+        assert route.rejected_waypoints == []
+
+    def test_near_route_waypoint_passes(self, model):
+        r = RouteResolver(model)
+        route = r.resolve("EGKK NEARR EDDF")
+        assert route.waypoints == ["NEARR"]
+        assert route.rejected_waypoints == []
+
+    def test_far_off_waypoint_rejected(self, model):
+        r = RouteResolver(model)
+        route = r.resolve("EGKK FAROFF EDDF")
+        assert route.waypoints == []
+        assert len(route.rejected_waypoints) == 1
+        entry = route.rejected_waypoints[0]
+        assert entry["name"] == "FAROFF"
+        assert entry["reason"] == "detour_exceeds_threshold"
+        assert entry["detour_nm"] > entry["threshold_nm"]
+
+    def test_short_leg_floor_accepts_terminal_fix(self, model):
+        """Short legs use the floor, tolerating near-route terminal fixes."""
+        # EGKA→EGKB is ~24 nm; TERMN is ~12 nm off course → should pass.
+        r = RouteResolver(model)
+        route = r.resolve("EGKA TERMN EGKB")
+        assert route.waypoints == ["TERMN"]
+        assert route.rejected_waypoints == []
+
+    def test_long_leg_cap_rejects_very_far_off(self, model):
+        """Cap bounds permissiveness even on long legs."""
+        # Manually tighten cap so FAROFF is clearly out of bounds
+        r = RouteResolver(model, detour_cap_nm=200)
+        route = r.resolve("EGKK FAROFF EDDF")
+        assert route.rejected_waypoints
+        assert route.rejected_waypoints[0]["threshold_nm"] <= 200
+
+    def test_candidate_selection_picks_min_detour(self, model):
+        """When multiple candidates exist, the on-route one is chosen."""
+        r = RouteResolver(model)
+        route = r.resolve("EGKK AMBIG EDDF")
+        # Should pick the near candidate (lat ~50.5) not the far one (lat 35)
+        assert route.waypoints == ["AMBIG"]
+        assert len(route.waypoint_coords) == 1
+        assert abs(route.waypoint_coords[0].latitude - 50.5) < 0.1
+        assert route.rejected_waypoints == []
+
+    def test_bad_point_does_not_pollute_subsequent_anchor(self, model):
+        """A rejected point must not move the reference — next fix still
+        scored against the last good anchor."""
+        r = RouteResolver(model)
+        # FAROFF (in Spain) between two on-route fixes. If rejection moved
+        # the anchor to Spain, NEARR would then fail too. It must still pass.
+        route = r.resolve("EGKK FAROFF NEARR EDDF")
+        assert "NEARR" in route.waypoints
+        assert any(rej["name"] == "FAROFF" for rej in route.rejected_waypoints)
+
+    def test_rejected_waypoints_roundtrip(self, model):
+        r = RouteResolver(model)
+        route = r.resolve("EGKK FAROFF EDDF")
+        d = route.to_dict()
+        assert d["rejected_waypoints"]
+        route2 = Route.from_dict(d)
+        assert route2.rejected_waypoints == route.rejected_waypoints


### PR DESCRIPTION
## Summary

Implements #4. Adds `parse_field15`, a pure, DB-free tokenizer for ICAO Field-15 route strings. Classifies each token (waypoint / airway / speed_level / flight_rule / direct / unknown), preserves order so callers can reconstruct intent or give positional feedback, and captures `POINT/QUALIFIER` splits as one token rather than two.

`RouteResolver.resolve` now builds its waypoint list from `parse_field15` instead of the inline `DCT`/`->`/`TO` string filter. This makes realistic pasted FPL input parse cleanly — no more `IFR`, `VFR`, `UL612`, `N0180F080` or `BILGO/N0175F100` showing up as 'unresolvable'.

### API

```python
from euro_aip.models import parse_field15, waypoints_of, TokenKind

tokens = parse_field15("N0175F160 EGTF DCT BILGO/N0180F100 UL612 XIDIL VFR LSGS")
waypoints_of(tokens)   # ['EGTF', 'BILGO', 'XIDIL', 'LSGS']
```

Re-exported from `euro_aip.models`: `TokenKind`, `RouteToken`, `parse_field15`, `waypoints_of`, `annotations_of`.

### RouteResolver integration

- Replaces `[t for t in tokens if t not in ("DCT", "->", "TO")]` with `waypoints_of(parse_field15(...))`.
- Adds a DB-grounded demotion pass: tokens classified as `AIRWAY` or `UNKNOWN` that actually resolve to a known point are promoted to `WAYPOINT`. Keeps the parser strict to ICAO grammar while letting the resolver absorb real-world oddities (e.g. 6-letter point names that live in some nav databases). Covers the original AIRWAY-vs-point disambiguation described in the issue plus the `UNKNOWN` case surfaced by existing detour-filter tests.

### Tests

New `tests/test_models/test_field15.py` (35 tests):
- Each `TokenKind` in isolation
- The motivating example from the issue end-to-end
- Order preservation and positional offsets
- `POINT/QUALIFIER` split with qualifier captured
- Empty / whitespace / lowercase / mixed-case input
- Round-trip property (`' '.join(t.raw for t in parse_field15(s)) == s`)
- Airway-vs-waypoint boundary cases

Full suite: **646 passed**.

### Scope

- **In**: parser module, exports, `RouteResolver.resolve` integration, airway/unknown demotion.
- **Out**: `euro_aip/briefing/models/icao_fpl.py::_parse_route_tokens` — has similar duplicated logic, but cleanup there is flagged as a separate PR in the issue, and bundling it would widen the blast radius. Same for the flyfun-weather downstream work.

## Test plan

- [x] `pytest tests/test_models/test_field15.py` — 35 tests pass
- [x] `pytest tests/test_models/` — 134 tests pass (no detour-filter regressions)
- [x] `pytest tests/` — 646 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)