### PR TITLE
fix: convert Autorouter NOTAM lat/lon from Garmin semicircles to degrees

### DIFF
--- a/euro_aip/euro_aip/briefing/sources/autorouter_notam.py
+++ b/euro_aip/euro_aip/briefing/sources/autorouter_notam.py
@@ -21,6 +21,9 @@ logger = logging.getLogger(__name__)
 _PAGE_LIMIT = 100
 # Maximum ICAOs per request to avoid URL length issues
 _ICAO_BATCH_SIZE = 20
+# API returns lat/lon as Garmin semicircles (2**31 = 180°), per
+# https://www.autorouter.aero/wiki/api/notams/
+_SEMICIRCLES_PER_DEGREE = (2 ** 31) / 180.0
 
 
 class AutorouterNotamSource:
@@ -169,10 +172,14 @@ class AutorouterNotamSource:
         # Category from Q-code
         category = NotamCategory.from_q_code(q_code) if q_code else None
 
-        # Coordinates
-        lat = row.get("lat")
-        lon = row.get("lon")
-        coordinates = (lat, lon) if lat is not None and lon is not None else None
+        # Coordinates: API returns Garmin semicircles, convert to decimal degrees.
+        lat_raw = row.get("lat")
+        lon_raw = row.get("lon")
+        if lat_raw is not None and lon_raw is not None:
+            coordinates = (lat_raw / _SEMICIRCLES_PER_DEGREE,
+                           lon_raw / _SEMICIRCLES_PER_DEGREE)
+        else:
+            coordinates = None
 
         # Validity times (unix epoch → datetime UTC)
         start_epoch = row.get("startvalidity")


### PR DESCRIPTION
## Summary

- The Autorouter NOTAM API returns `lat`/`lon` as Garmin-format integer semicircles (`2**31 = 180°`) per [the API docs](https://www.autorouter.aero/wiki/api/notams/), but `_row_to_notam` was reading them as decimal degrees.
- One-line fix: divide raw values by `(2**31) / 180`.
- The bug was latent because no downstream caller was using `Notam.coordinates` from this source yet. Surfacing now because the FlyFunBrief iOS app is about to start consuming the API output for distance/route filtering.

## Verification

Verified empirically against 215 LFFF NOTAMs from a real API response:

```
raw lat=580615949 lon=36785599
  if decimal degrees:    (580615949.0000, 36785599.0000)   ← nonsense
  if Garmin semicircles: (48.6667, 3.0833)                  ← Paris FIR ✓

raw lat=591949890 lon=-10737418
  if Garmin semicircles: (49.6167, -0.9000)                 ← Normandy ✓

raw lat=586382340 lon=53687091
  if Garmin semicircles: (49.1500, 4.5000)                  ← Champagne ✓
```

Companion PR on flyfun-apps wires this into `/api/briefing/notams`: https://github.com/roznet/flyfun-apps/pull/37

## Test plan

- [ ] Existing tests still pass.
- [ ] Sanity check: `AutorouterNotamSource.fetch_notams(['LFFF'])` returns NOTAMs whose `coordinates` lie within the Paris FIR bounding box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)