### PR TITLE
fix(route_resolver): accept middle waypoints on round-trip routes

### DIFF
--- a/euro_aip/euro_aip/models/route_resolver.py
+++ b/euro_aip/euro_aip/models/route_resolver.py
@@ -315,32 +315,36 @@ class RouteResolver:
                 logger.warning("Could not resolve waypoint: %s", token)
                 continue
 
-            # Detour gate — only applies when we have both anchors
+            # Detour gate — only applies when we have both anchors AND a
+            # real leg between them. For closed-loop routes (dep == dest)
+            # leg_nm collapses to 0 and the detour metric reduces to
+            # 2·d(ref, candidate), which would reject every middle point.
             if reference is not None and forward is not None:
-                candidate_np = NavPoint(
-                    latitude=point.latitude,
-                    longitude=point.longitude,
-                    name=point.name,
-                )
                 _, leg_nm = reference.haversine_distance(forward)
-                detour = NavPoint.detour_nm(reference, candidate_np, forward)
-                threshold = self._detour_threshold_nm(leg_nm)
-                if detour > threshold:
-                    rejected.append({
-                        "name": token,
-                        "reason": "detour_exceeds_threshold",
-                        "detour_nm": round(detour, 1),
-                        "leg_nm": round(leg_nm, 1),
-                        "threshold_nm": round(threshold, 1),
-                    })
-                    logger.warning(
-                        "Route '%s': rejecting %s — detour %.0f nm exceeds "
-                        "threshold %.0f nm on %.0f nm leg (%s→%s)",
-                        route_string, token, detour, threshold, leg_nm,
-                        reference.name, forward.name,
+                if leg_nm >= 1.0:
+                    candidate_np = NavPoint(
+                        latitude=point.latitude,
+                        longitude=point.longitude,
+                        name=point.name,
                     )
-                    # Do not advance reference — keep anchoring on last good point
-                    continue
+                    detour = NavPoint.detour_nm(reference, candidate_np, forward)
+                    threshold = self._detour_threshold_nm(leg_nm)
+                    if detour > threshold:
+                        rejected.append({
+                            "name": token,
+                            "reason": "detour_exceeds_threshold",
+                            "detour_nm": round(detour, 1),
+                            "leg_nm": round(leg_nm, 1),
+                            "threshold_nm": round(threshold, 1),
+                        })
+                        logger.warning(
+                            "Route '%s': rejecting %s — detour %.0f nm exceeds "
+                            "threshold %.0f nm on %.0f nm leg (%s→%s)",
+                            route_string, token, detour, threshold, leg_nm,
+                            reference.name, forward.name,
+                        )
+                        # Do not advance reference — keep anchoring on last good point
+                        continue
 
             waypoint_names.append(token)
             # Override point_type for intermediate points

--- a/euro_aip/tests/test_models/test_waypoint.py
+++ b/euro_aip/tests/test_models/test_waypoint.py
@@ -664,3 +664,20 @@ class TestDetourFilter:
         assert d["rejected_waypoints"]
         route2 = Route.from_dict(d)
         assert route2.rejected_waypoints == route.rejected_waypoints
+
+    def test_round_trip_route_accepts_middle_waypoint(self, model):
+        """When dep == dest, leg_nm is 0 — middle waypoints must not be
+        rejected by a degenerate detour gate."""
+        r = RouteResolver(model)
+        route = r.resolve("EGKK TERMN EGKK")
+        assert route.waypoints == ["TERMN"]
+        assert route.rejected_waypoints == []
+
+    def test_round_trip_route_with_far_middle_still_accepted(self, model):
+        """No 'direct route' exists for a loop, so the detour gate is
+        disabled on the degenerate leg — even FAROFF (Spain, ~700 nm from
+        EGKK) passes when it's the only middle waypoint."""
+        r = RouteResolver(model)
+        route = r.resolve("EGKK FAROFF EGKK")
+        assert route.waypoints == ["FAROFF"]
+        assert route.rejected_waypoints == []


### PR DESCRIPTION
## Summary
- Fixes #8 — `RouteResolver.resolve()` no longer rejects every middle waypoint when departure equals destination.
- Skip the detour gate when `leg_nm < 1.0`, mirroring the `dist_AB` guard in `NavPoint.distance_to_segment`. For closed loops (`dep == dest`), the detour metric collapses to `2·d(ref, candidate)` and the threshold falls back to the floor, so any waypoint > ~15 nm from home would otherwise be rejected.
- Two new tests in `TestDetourFilter` cover the near and far round-trip cases.

## Test plan
- [x] `pytest tests/test_models/test_waypoint.py` — 71 passed, including the two new round-trip tests.
- [x] Issue's exact repro (`EGTF EGMC EGTF`) now returns `waypoints=['EGMC']` with empty `rejected_waypoints`.
- [x] Existing `TestDetourFilter` and `TestRouteResolver` cases unaffected (non-loop routes still get the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)