### PR TITLE
fix(briefing/avwx): retry transient aviationweather.gov fetch failures

### DIFF
--- a/euro_aip/euro_aip/briefing/sources/avwx.py
+++ b/euro_aip/euro_aip/briefing/sources/avwx.py
@@ -1,6 +1,7 @@
 """Aviation Weather (aviationweather.gov) API source for live METAR/TAF/SIGMET data."""
 
 import logging
+import time
 from typing import Any, List, Optional
 
 import requests
@@ -31,16 +32,30 @@ class AvWxSource:
     BASE_URL = "https://aviationweather.gov/api/data"
     BATCH_SIZE = 400
     DEFAULT_TIMEOUT = 15
+    DEFAULT_MAX_RETRIES = 2
+    DEFAULT_RETRY_BACKOFF = 0.5
     USER_AGENT = "euro-aip/1.0 (aviation weather tool)"
 
-    def __init__(self, session: Optional[requests.Session] = None, timeout: int = DEFAULT_TIMEOUT):
+    def __init__(
+        self,
+        session: Optional[requests.Session] = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        retry_backoff: float = DEFAULT_RETRY_BACKOFF,
+    ):
         """
         Args:
             session: Optional requests.Session for dependency injection (testing).
             timeout: HTTP request timeout in seconds.
+            max_retries: Extra attempts on transient failures (timeouts,
+                connection errors, 5xx). 0 disables retrying.
+            retry_backoff: Base seconds for linear backoff between attempts
+                (attempt N waits ``retry_backoff * N``).
         """
         self._session = session or requests.Session()
         self._timeout = timeout
+        self._max_retries = max(0, max_retries)
+        self._retry_backoff = retry_backoff
         self._session.headers.setdefault("User-Agent", self.USER_AGENT)
 
     def fetch_metars(self, icaos: List[str], hours: float = 3) -> List[WeatherReport]:
@@ -161,6 +176,36 @@ class AvWxSource:
                 logger.warning("Failed to parse SIGMET entry: %s", e)
         return reports
 
+    def _get_with_retry(self, url: str, params: dict) -> requests.Response:
+        """GET ``url`` with retries on transient failures.
+
+        aviationweather.gov intermittently read-times-out; because METAR/TAF
+        are fetched in batches of up to ``BATCH_SIZE``, a single un-retried
+        timeout silently drops a whole batch of airports for that ingest cycle.
+        Retries cover connection errors, read timeouts, and 5xx responses
+        (4xx are returned as-is — retrying a client error won't help). Raises
+        the last exception if every attempt fails, so callers keep their
+        existing fail-open (return empty) behaviour.
+        """
+        last_exc: Exception = RuntimeError("no request attempted")
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = self._session.get(url, params=params, timeout=self._timeout)
+                if response.status_code < 500:
+                    return response
+                last_exc = requests.HTTPError(
+                    f"{response.status_code} Server Error", response=response,
+                )
+            except requests.RequestException as e:
+                last_exc = e
+            if attempt < self._max_retries:
+                logger.debug(
+                    "AvWx GET attempt %d/%d failed (%s) — retrying",
+                    attempt + 1, self._max_retries + 1, last_exc,
+                )
+                time.sleep(self._retry_backoff * (attempt + 1))
+        raise last_exc
+
     def _fetch_raw(self, endpoint: str, params: dict) -> str:
         """
         Make HTTP GET request and return raw text.
@@ -169,7 +214,7 @@ class AvWxSource:
         """
         url = f"{self.BASE_URL}/{endpoint}"
         try:
-            response = self._session.get(url, params=params, timeout=self._timeout)
+            response = self._get_with_retry(url, params)
             if response.status_code == 204:
                 return ""
             response.raise_for_status()
@@ -188,7 +233,7 @@ class AvWxSource:
         """
         url = f"{self.BASE_URL}/{endpoint}"
         try:
-            response = self._session.get(url, params=params, timeout=self._timeout)
+            response = self._get_with_retry(url, params)
             if response.status_code == 204:
                 return []
             response.raise_for_status()

--- a/euro_aip/pyproject.toml
+++ b/euro_aip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "euro_aip"
-version = "0.10.0"
+version = "0.10.1"
 description = "A library for parsing and managing European AIP (Aeronautical Information Publication) data"
 readme = "README.md"
 authors = [

--- a/euro_aip/tests/briefing/test_weather/test_avwx_source.py
+++ b/euro_aip/tests/briefing/test_weather/test_avwx_source.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 import pytest
+from requests.exceptions import Timeout
 
 from euro_aip.briefing.sources.avwx import AvWxSource
 from euro_aip.briefing.weather.models import WeatherType, FlightCategory
@@ -372,3 +373,56 @@ class TestErrorHandling:
         call_kwargs = session.get.call_args
         ids = call_kwargs[1]["params"]["ids"]
         assert ids == "EGLL,LFPG"
+
+
+class TestRetry:
+    """Retry behaviour on transient failures (timeouts, connection errors, 5xx)."""
+
+    VALID_METAR = "METAR EGLL 211250Z 27010KT 9999 SCT030 BKN045 15/08 Q1020"
+
+    def test_retries_then_succeeds(self):
+        session = make_session()
+        session.get.side_effect = [
+            Timeout("read timed out"),
+            MockResponse(self.VALID_METAR),
+        ]
+        source = AvWxSource(session=session, retry_backoff=0)
+
+        reports = source.fetch_metars(["EGLL"])
+
+        assert len(reports) == 1
+        assert reports[0].icao == "EGLL"
+        assert session.get.call_count == 2  # one failure + one success
+
+    def test_exhausts_retries_returns_empty(self):
+        session = make_session()
+        session.get.side_effect = Timeout("read timed out")
+        source = AvWxSource(session=session, max_retries=2, retry_backoff=0)
+
+        reports = source.fetch_metars(["EGLL"])
+
+        assert reports == []
+        assert session.get.call_count == 3  # max_retries + 1
+
+    def test_no_retry_when_disabled(self):
+        session = make_session()
+        session.get.side_effect = Timeout("read timed out")
+        source = AvWxSource(session=session, max_retries=0, retry_backoff=0)
+
+        reports = source.fetch_metars(["EGLL"])
+
+        assert reports == []
+        assert session.get.call_count == 1
+
+    def test_5xx_is_retried(self):
+        session = make_session()
+        session.get.side_effect = [
+            MockResponse("", status_code=503),
+            MockResponse(self.VALID_METAR),
+        ]
+        source = AvWxSource(session=session, retry_backoff=0)
+
+        reports = source.fetch_metars(["EGLL"])
+
+        assert len(reports) == 1
+        assert session.get.call_count == 2


### PR DESCRIPTION
## Summary
`AvWxSource._fetch_raw` / `_fetch_json` made a single GET and, on any failure, swallowed the exception and returned empty. Because METAR/TAF are fetched in batches of up to `BATCH_SIZE` (400), a single un-retried read timeout silently dropped a whole batch of airports for that fetch.

Observed in flyfun-weather prod: ~46 `AvWx fetch failed` warnings/day, ~1 per 30-min METAR-ingest cycle (the watchlist is 619 airports = 2 batches, so one timed-out batch loses up to ~400 airports' obs for that cycle), spread evenly — chronic per-request flakiness, not an outage.

## Changes
- New `_get_with_retry()` used by both `_fetch_raw` and `_fetch_json`. Retries connection errors, read timeouts, and 5xx responses with linear backoff; returns 4xx as-is (retrying a client error won't help). Raises the last exception once attempts are exhausted, so callers keep their existing fail-open (return empty) behaviour.
- `AvWxSource.__init__` gains `max_retries` (default 2) and `retry_backoff` (default 0.5s), so callers can tune or disable retrying.
- Version bump 0.10.0 → 0.10.1.

## Test plan
- [x] 4 new `TestRetry` cases: retry-then-succeed, exhaust-retries-fail-open, no-retry-when-disabled, 5xx-retried.
- [x] Full `test_avwx_source.py` suite green (35 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)