### PR TITLE
Implement FlightExchange cross-app flight interchange model

### DIFF
--- a/Sources/RZFlight/Briefing/FlightExchange.swift
+++ b/Sources/RZFlight/Briefing/FlightExchange.swift
@@ -1,0 +1,155 @@
+//
+//  FlightExchange.swift
+//  RZFlight
+//
+//  Cross-app flight interchange model.
+//  Mirrors the Python euro_aip.briefing.models.FlightExchange wire format.
+//
+
+import Foundation
+
+/// A shared, language-neutral representation of a "flight" (route + timing +
+/// aircraft) that round-trips between the Python server (`euro_aip`) and the
+/// Swift apps (`RZFlight`), so a flight can be exported from one flyfun app and
+/// imported into another.
+///
+/// `FlightExchange` is a thin envelope around the existing ``Route`` type: the
+/// `route` JSON object is `Route`'s coding embedded verbatim, so the two never
+/// drift. The envelope only adds the fields that are *not* on ``Route``: a
+/// display ``name``, the aircraft ``registration``, provenance (``source``),
+/// and a ``schemaVersion``.
+///
+/// See `designs/flight_exchange_design.md` for the full wire format. The Python
+/// counterpart lives in `euro_aip/briefing/models/flight_exchange.py` and must
+/// stay in parity.
+public struct FlightExchange: Codable, Sendable {
+
+    /// Wire format version. v1 == designs/flight_exchange_design.md.
+    public static let currentSchemaVersion: Int = 1
+
+    // MARK: - Nested Types
+
+    /// Provenance — where the flight came from. All fields optional.
+    public struct Source: Codable, Sendable {
+        /// Emitting app: "weather" | "forms" | "brief".
+        public var app: String?
+
+        /// Sender's native flight id (opaque to the consumer).
+        public var flightId: String?
+
+        /// Present when the sender supports public re-fetch.
+        public var shareCode: String?
+
+        enum CodingKeys: String, CodingKey {
+            case app
+            case flightId = "flight_id"
+            case shareCode = "share_code"
+        }
+
+        public init(app: String? = nil, flightId: String? = nil, shareCode: String? = nil) {
+            self.app = app
+            self.flightId = flightId
+            self.shareCode = shareCode
+        }
+    }
+
+    /// Aircraft envelope — the cross-app fields not carried on ``Route``.
+    public struct Aircraft: Codable, Sendable {
+        /// Aircraft registration — the cross-app field none store on the route today.
+        public var registration: String?
+
+        /// Convenience mirror of `route.aircraftType` (the route stays the source of truth).
+        public var type: String?
+
+        public init(registration: String? = nil, type: String? = nil) {
+            self.registration = registration
+            self.type = type
+        }
+    }
+
+    // MARK: - Fields
+
+    /// Wire format version (v1 = current).
+    public var schemaVersion: Int
+
+    /// Optional provenance.
+    public var source: Source?
+
+    /// Optional display title (e.g. "Oxford -> Sion").
+    public var name: String?
+
+    /// The flight route — the single source of route truth.
+    public var route: Route
+
+    /// Optional aircraft envelope (registration + type mirror).
+    public var aircraft: Aircraft?
+
+    // MARK: - CodingKeys
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case source
+        case name
+        case route
+        case aircraft
+    }
+
+    // MARK: - Decoding
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
+            ?? FlightExchange.currentSchemaVersion
+        self.source = try container.decodeIfPresent(Source.self, forKey: .source)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.route = try container.decode(Route.self, forKey: .route)
+        self.aircraft = try container.decodeIfPresent(Aircraft.self, forKey: .aircraft)
+    }
+}
+
+// MARK: - Memberwise Initializer
+
+extension FlightExchange {
+    /// Create a FlightExchange with all fields specified.
+    public init(
+        route: Route,
+        schemaVersion: Int = FlightExchange.currentSchemaVersion,
+        name: String? = nil,
+        source: Source? = nil,
+        aircraft: Aircraft? = nil
+    ) {
+        self.route = route
+        self.schemaVersion = schemaVersion
+        self.name = name
+        self.source = source
+        self.aircraft = aircraft
+    }
+}
+
+// MARK: - Convenience Coding
+
+extension FlightExchange {
+    /// Decode a FlightExchange from JSON data, using the snake_case + ISO-8601
+    /// conventions of the Python wire format.
+    public static func decode(from data: Data) throws -> FlightExchange {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(FlightExchange.self, from: data)
+    }
+
+    /// Encode this FlightExchange to JSON data in the language-neutral wire
+    /// format (snake_case keys, ISO-8601 UTC times).
+    public func encoded() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(self)
+    }
+}
+
+// MARK: - Protocol Conformances
+
+extension FlightExchange: CustomStringConvertible {
+    public var description: String {
+        return "FlightExchange(\(route.departure) -> \(route.destination), v\(schemaVersion))"
+    }
+}

--- a/Sources/RZFlight/Briefing/FlightExchange.swift
+++ b/Sources/RZFlight/Briefing/FlightExchange.swift
@@ -100,6 +100,15 @@ public struct FlightExchange: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion)
             ?? FlightExchange.currentSchemaVersion
+        // Reject unknown (newer) schema versions — a v2 payload may carry
+        // breaking changes this build can't interpret. See design doc.
+        guard self.schemaVersion <= FlightExchange.currentSchemaVersion else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .schemaVersion, in: container,
+                debugDescription: "Unsupported FlightExchange schema_version "
+                    + "\(self.schemaVersion) (max supported "
+                    + "\(FlightExchange.currentSchemaVersion))")
+        }
         self.source = try container.decodeIfPresent(Source.self, forKey: .source)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
         self.route = try container.decode(Route.self, forKey: .route)

--- a/Tests/RZFlightTests/RZFlightFlightExchangeTests.swift
+++ b/Tests/RZFlightTests/RZFlightFlightExchangeTests.swift
@@ -1,0 +1,163 @@
+//
+//  RZFlightFlightExchangeTests.swift
+//  RZFlightTests
+//
+//  Tests for FlightExchange — the cross-app flight interchange model.
+//  Decodes the shared parity fixtures (emitted by the Python side) and checks
+//  the round-trip invariant. See designs/flight_exchange_design.md.
+//
+
+import XCTest
+@testable import RZFlight
+
+final class RZFlightFlightExchangeTests: XCTestCase {
+
+    // MARK: - Shared fixtures
+
+    /// Shared cross-platform parity fixtures live at the repo root so both the
+    /// Swift and Python test suites read the exact same JSON.
+    static func fixturesDirectory() -> URL {
+        // #file == <repo>/Tests/RZFlightTests/RZFlightFlightExchangeTests.swift
+        return URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()   // RZFlightTests
+            .deletingLastPathComponent()   // Tests
+            .deletingLastPathComponent()   // <repo>
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("fixtures")
+            .appendingPathComponent("flight_exchange")
+    }
+
+    func loadFixture(_ name: String) throws -> Data {
+        let url = Self.fixturesDirectory().appendingPathComponent(name)
+        return try Data(contentsOf: url)
+    }
+
+    // MARK: - Decoding Python-emitted fixtures
+
+    func testDecodeFullFixture() throws {
+        let data = try loadFixture("full.json")
+        let fx = try FlightExchange.decode(from: data)
+
+        XCTAssertEqual(fx.schemaVersion, 1)
+        XCTAssertEqual(fx.name, "Oxford -> Sion")
+
+        // Envelope
+        XCTAssertEqual(fx.source?.app, "weather")
+        XCTAssertEqual(fx.source?.flightId, "egtk_lsgs-2026-06-01-a1b2")
+        XCTAssertEqual(fx.source?.shareCode, "Ab3xY9k2")
+        XCTAssertEqual(fx.aircraft?.registration, "HB-ABC")
+        XCTAssertEqual(fx.aircraft?.type, "P28A")
+
+        // Route embedded verbatim
+        XCTAssertEqual(fx.route.departure, "EGTK")
+        XCTAssertEqual(fx.route.destination, "LSGS")
+        XCTAssertEqual(fx.route.alternates, ["LSGG"])
+        XCTAssertEqual(fx.route.waypoints, ["BILGO", "XIDIL"])
+        XCTAssertEqual(fx.route.aircraftType, "P28A")
+        XCTAssertEqual(fx.route.cruiseAltitudeFt, 8000)
+        XCTAssertNil(fx.route.flightLevel)
+        XCTAssertEqual(fx.route.waypointCoords.count, 2)
+        XCTAssertEqual(fx.route.waypointCoords.first?.name, "BILGO")
+
+        // Coordinates resolve
+        XCTAssertEqual(fx.route.departureCoordinate?.latitude ?? 0, 51.83, accuracy: 0.0001)
+        XCTAssertEqual(fx.route.destinationCoordinate?.longitude ?? 0, 7.33, accuracy: 0.0001)
+        XCTAssertEqual(fx.route.coordinate(for: "LSGG")?.latitude ?? 0, 46.24, accuracy: 0.0001)
+
+        // Times — Python emits ISO-8601 with +00:00 offset; must decode as UTC.
+        let expectedDeparture = ISO8601DateFormatter().date(from: "2026-06-01T09:00:00Z")
+        XCTAssertEqual(fx.route.departureTime, expectedDeparture)
+        let expectedArrival = ISO8601DateFormatter().date(from: "2026-06-01T11:15:00Z")
+        XCTAssertEqual(fx.route.arrivalTime, expectedArrival)
+    }
+
+    func testDecodeMinimalFixture() throws {
+        let data = try loadFixture("minimal.json")
+        let fx = try FlightExchange.decode(from: data)
+
+        XCTAssertEqual(fx.schemaVersion, 1)
+        XCTAssertEqual(fx.route.departure, "EGTF")
+        XCTAssertEqual(fx.route.destination, "EGLL")
+        XCTAssertNil(fx.name)
+        XCTAssertNil(fx.source)
+        XCTAssertNil(fx.aircraft)
+        XCTAssertNil(fx.route.departureTime)
+        XCTAssertTrue(fx.route.alternates.isEmpty)
+        XCTAssertTrue(fx.route.waypoints.isEmpty)
+    }
+
+    // MARK: - Round-trip invariant
+
+    func testFullRoundTrip() throws {
+        let data = try loadFixture("full.json")
+        let original = try FlightExchange.decode(from: data)
+        let reencoded = try original.encoded()
+        let restored = try FlightExchange.decode(from: reencoded)
+
+        assertEqual(restored, original)
+    }
+
+    func testMinimalRoundTrip() throws {
+        let data = try loadFixture("minimal.json")
+        let original = try FlightExchange.decode(from: data)
+        let reencoded = try original.encoded()
+        let restored = try FlightExchange.decode(from: reencoded)
+
+        assertEqual(restored, original)
+    }
+
+    func testMemberwiseRoundTrip() throws {
+        let route = Route(
+            departure: "EGTK",
+            destination: "LSGS",
+            alternates: ["LSGG"],
+            waypoints: ["BILGO"],
+            departureCoords: [51.83, -1.32],
+            destinationCoords: [46.22, 7.33],
+            aircraftType: "P28A",
+            departureTime: Date(timeIntervalSince1970: 1_780_000_000),
+            cruiseAltitudeFt: 8000
+        )
+        let original = FlightExchange(
+            route: route,
+            name: "Test",
+            source: FlightExchange.Source(app: "forms", flightId: "f-1"),
+            aircraft: FlightExchange.Aircraft(registration: "G-ABCD", type: "P28A")
+        )
+        let restored = try FlightExchange.decode(from: original.encoded())
+        assertEqual(restored, original)
+    }
+
+    // MARK: - Defaults
+
+    func testSchemaVersionDefaultsWhenMissing() throws {
+        let json = """
+        { "route": { "departure": "EGTF", "destination": "EGLL" } }
+        """.data(using: .utf8)!
+        let fx = try FlightExchange.decode(from: json)
+        XCTAssertEqual(fx.schemaVersion, FlightExchange.currentSchemaVersion)
+    }
+
+    // MARK: - Helpers
+
+    private func assertEqual(_ a: FlightExchange, _ b: FlightExchange,
+                             file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(a.schemaVersion, b.schemaVersion, file: file, line: line)
+        XCTAssertEqual(a.name, b.name, file: file, line: line)
+        XCTAssertEqual(a.source?.app, b.source?.app, file: file, line: line)
+        XCTAssertEqual(a.source?.flightId, b.source?.flightId, file: file, line: line)
+        XCTAssertEqual(a.source?.shareCode, b.source?.shareCode, file: file, line: line)
+        XCTAssertEqual(a.aircraft?.registration, b.aircraft?.registration, file: file, line: line)
+        XCTAssertEqual(a.aircraft?.type, b.aircraft?.type, file: file, line: line)
+        XCTAssertEqual(a.route.departure, b.route.departure, file: file, line: line)
+        XCTAssertEqual(a.route.destination, b.route.destination, file: file, line: line)
+        XCTAssertEqual(a.route.alternates, b.route.alternates, file: file, line: line)
+        XCTAssertEqual(a.route.waypoints, b.route.waypoints, file: file, line: line)
+        XCTAssertEqual(a.route.aircraftType, b.route.aircraftType, file: file, line: line)
+        XCTAssertEqual(a.route.cruiseAltitudeFt, b.route.cruiseAltitudeFt, file: file, line: line)
+        XCTAssertEqual(a.route.flightLevel, b.route.flightLevel, file: file, line: line)
+        XCTAssertEqual(a.route.departureTime, b.route.departureTime, file: file, line: line)
+        XCTAssertEqual(a.route.arrivalTime, b.route.arrivalTime, file: file, line: line)
+        XCTAssertEqual(a.route.waypointCoords, b.route.waypointCoords, file: file, line: line)
+    }
+}

--- a/Tests/RZFlightTests/RZFlightFlightExchangeTests.swift
+++ b/Tests/RZFlightTests/RZFlightFlightExchangeTests.swift
@@ -17,8 +17,13 @@ final class RZFlightFlightExchangeTests: XCTestCase {
     /// Shared cross-platform parity fixtures live at the repo root so both the
     /// Swift and Python test suites read the exact same JSON.
     static func fixturesDirectory() -> URL {
-        // #file == <repo>/Tests/RZFlightTests/RZFlightFlightExchangeTests.swift
-        return URL(fileURLWithPath: #file)
+        // The fixtures intentionally live at <repo>/Tests/fixtures so the Python
+        // and Swift suites read the byte-identical files. That path sits outside
+        // the test target's directory, so it can't be an SPM `Bundle.module`
+        // resource — resolve it relative to this source file instead.
+        // Use #filePath (always a full filesystem path) rather than #file, which
+        // can be a concise module-relative string under some build settings.
+        return URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()   // RZFlightTests
             .deletingLastPathComponent()   // Tests
             .deletingLastPathComponent()   // <repo>
@@ -136,6 +141,15 @@ final class RZFlightFlightExchangeTests: XCTestCase {
         """.data(using: .utf8)!
         let fx = try FlightExchange.decode(from: json)
         XCTAssertEqual(fx.schemaVersion, FlightExchange.currentSchemaVersion)
+    }
+
+    /// A payload from a newer (unknown) schema version is rejected rather than
+    /// silently decoded — the design doc says consumers reject unknown versions.
+    func testRejectsNewerSchemaVersion() throws {
+        let json = """
+        { "schema_version": 999, "route": { "departure": "EGTF", "destination": "EGLL" } }
+        """.data(using: .utf8)!
+        XCTAssertThrowsError(try FlightExchange.decode(from: json))
     }
 
     // MARK: - Helpers

--- a/Tests/fixtures/flight_exchange/full.json
+++ b/Tests/fixtures/flight_exchange/full.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": 1,
+  "route": {
+    "departure": "EGTK",
+    "destination": "LSGS",
+    "alternates": [
+      "LSGG"
+    ],
+    "waypoints": [
+      "BILGO",
+      "XIDIL"
+    ],
+    "departure_coords": [
+      51.83,
+      -1.32
+    ],
+    "destination_coords": [
+      46.22,
+      7.33
+    ],
+    "alternate_coords": {
+      "LSGG": [
+        46.24,
+        6.11
+      ]
+    },
+    "waypoint_coords": [
+      {
+        "name": "BILGO",
+        "latitude": 48.5,
+        "longitude": 2.17,
+        "point_type": "waypoint"
+      },
+      {
+        "name": "XIDIL",
+        "latitude": 47.1,
+        "longitude": 5.4,
+        "point_type": "waypoint"
+      }
+    ],
+    "rejected_waypoints": [],
+    "aircraft_type": "P28A",
+    "departure_time": "2026-06-01T09:00:00+00:00",
+    "arrival_time": "2026-06-01T11:15:00+00:00",
+    "flight_level": null,
+    "cruise_altitude_ft": 8000
+  },
+  "name": "Oxford -> Sion",
+  "source": {
+    "app": "weather",
+    "flight_id": "egtk_lsgs-2026-06-01-a1b2",
+    "share_code": "Ab3xY9k2"
+  },
+  "aircraft": {
+    "registration": "HB-ABC",
+    "type": "P28A"
+  }
+}

--- a/Tests/fixtures/flight_exchange/minimal.json
+++ b/Tests/fixtures/flight_exchange/minimal.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "route": {
+    "departure": "EGTF",
+    "destination": "EGLL",
+    "alternates": [],
+    "waypoints": [],
+    "departure_coords": null,
+    "destination_coords": null,
+    "alternate_coords": {},
+    "waypoint_coords": [],
+    "rejected_waypoints": [],
+    "aircraft_type": null,
+    "departure_time": null,
+    "arrival_time": null,
+    "flight_level": null,
+    "cruise_altitude_ft": null
+  }
+}

--- a/designs/INDEX.md
+++ b/designs/INDEX.md
@@ -21,7 +21,7 @@ Two packages released independently from this repo with separate tag conventions
 
 ### RZFlight Swift Package
 Aviation calculations, airport data management, and flight planning for iOS/macOS. Wind calculations, runway selection, METAR integration, spatial airport/waypoint queries, route resolution, and native PDF briefing parsing.
-Key exports: `Airport`, `Runway`, `Procedure`, `RunwayWindModel`, `KnownAirports`, `Waypoint`, `KnownWaypoints`, `RoutePointResolver`, `ICAOFlightPlanParser`, `Briefing`, `Notam`, `ForeFlightParser`
+Key exports: `Airport`, `Runway`, `Procedure`, `RunwayWindModel`, `KnownAirports`, `Waypoint`, `KnownWaypoints`, `RoutePointResolver`, `ICAOFlightPlanParser`, `Briefing`, `Notam`, `ForeFlightParser`, `Route`, `FlightExchange`
 
 **Documentation:**
 - `swift_package.md` - Package overview, quick start
@@ -58,7 +58,7 @@ Documentation for European AIP web sources and data retrieval.
 
 ### Python Euro AIP Briefing
 Flight briefing data extraction, NOTAM filtering, and weather analysis. Parse ForeFlight PDFs, fetch live or historical METARs/TAFs, extract NOTAMs, and filter with fluent API.
-Key exports: `Briefing`, `NotamCollection`, `WeatherCollection`, `ForeFlightSource`, `AutorouterNotamSource`, `AutorouterGrametSource`, `AvWxSource`, `OgimetSource`, `ICAOFlightPlan`, `parse_icao_fpl`, `CategorizationPipeline`, `WeatherReport`, `FlightCategory`, `Route`, `RoutePoint`
+Key exports: `Briefing`, `NotamCollection`, `WeatherCollection`, `ForeFlightSource`, `AutorouterNotamSource`, `AutorouterGrametSource`, `AvWxSource`, `OgimetSource`, `ICAOFlightPlan`, `parse_icao_fpl`, `CategorizationPipeline`, `WeatherReport`, `FlightCategory`, `Route`, `RoutePoint`, `FlightExchange`
 
 **Documentation (load in order of need):**
 - `briefing.md` - Overview, architecture, usage examples (read FIRST)

--- a/designs/flight_exchange_design.md
+++ b/designs/flight_exchange_design.md
@@ -4,7 +4,8 @@
 > that round-trips between the Python server (`euro_aip`) and the Swift apps (`RZFlight`),
 > so flights can be exported from one flyfun app and imported into another.
 
-**Status:** Proposed (design only — not yet implemented).
+**Status:** Implemented (v1) in both `RZFlight` (Swift) and `euro_aip` (Python). Per-app
+adoption (weather emit, forms/brief import) tracked separately.
 **Home:** rzflight, in both `RZFlight` (Swift) and `euro_aip` (Python), alongside `Route`.
 
 ## Intent

--- a/euro_aip/euro_aip/__init__.py
+++ b/euro_aip/euro_aip/__init__.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 from datetime import datetime
 
 
-__version__ = '0.10.2'
+__version__ = '0.11.0'
 __all__ = [
     'Airport',
     'NavPoint',

--- a/euro_aip/euro_aip/briefing/__init__.py
+++ b/euro_aip/euro_aip/briefing/__init__.py
@@ -32,6 +32,7 @@ from euro_aip.briefing.models.notam import Notam, NotamCategory
 from euro_aip.briefing.models.route import Route, RoutePoint
 from euro_aip.briefing.models.briefing import Briefing
 from euro_aip.briefing.models.icao_fpl import ICAOFlightPlan, parse_icao_fpl
+from euro_aip.briefing.models.flight_exchange import FlightExchange
 from euro_aip.briefing.collections.notam_collection import NotamCollection
 from euro_aip.briefing.sources.foreflight import ForeFlightSource
 from euro_aip.briefing.sources.avwx import AvWxSource
@@ -64,6 +65,7 @@ __all__ = [
     'Briefing',
     'ICAOFlightPlan',
     'parse_icao_fpl',
+    'FlightExchange',
     # Collections
     'NotamCollection',
     # Sources

--- a/euro_aip/euro_aip/briefing/models/__init__.py
+++ b/euro_aip/euro_aip/briefing/models/__init__.py
@@ -4,6 +4,7 @@ from euro_aip.briefing.models.notam import Notam, NotamCategory
 from euro_aip.briefing.models.route import Route, RoutePoint
 from euro_aip.briefing.models.briefing import Briefing
 from euro_aip.briefing.models.icao_fpl import ICAOFlightPlan, parse_icao_fpl
+from euro_aip.briefing.models.flight_exchange import FlightExchange, SCHEMA_VERSION
 
 __all__ = [
     'Notam',
@@ -13,4 +14,6 @@ __all__ = [
     'Briefing',
     'ICAOFlightPlan',
     'parse_icao_fpl',
+    'FlightExchange',
+    'SCHEMA_VERSION',
 ]

--- a/euro_aip/euro_aip/briefing/models/flight_exchange.py
+++ b/euro_aip/euro_aip/briefing/models/flight_exchange.py
@@ -98,9 +98,18 @@ class FlightExchange:
         source = data.get('source') or {}
         aircraft = data.get('aircraft') or {}
 
+        # Reject unknown (newer) schema versions — a v2 payload may carry
+        # breaking changes this build can't interpret. See design doc.
+        version = data.get('schema_version', SCHEMA_VERSION)
+        if version > SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported FlightExchange schema_version {version} "
+                f"(max supported {SCHEMA_VERSION})"
+            )
+
         return cls(
             route=Route.from_dict(data['route']),
-            schema_version=data.get('schema_version', SCHEMA_VERSION),
+            schema_version=version,
             name=data.get('name'),
             aircraft_registration=aircraft.get('registration'),
             source_app=source.get('app'),

--- a/euro_aip/euro_aip/briefing/models/flight_exchange.py
+++ b/euro_aip/euro_aip/briefing/models/flight_exchange.py
@@ -1,0 +1,115 @@
+"""FlightExchange — cross-app flight interchange model.
+
+A shared, language-neutral representation of a "flight" (route + timing +
+aircraft) that round-trips between the Python server (``euro_aip``) and the
+Swift apps (``RZFlight``), so flights can be exported from one flyfun app and
+imported into another.
+
+``FlightExchange`` is a thin envelope around the existing :class:`Route` type:
+the ``route`` JSON object is :meth:`Route.to_dict` embedded verbatim, so the
+two never drift. The envelope only adds the fields that are *not* on ``Route``:
+a display ``name``, the aircraft ``registration``, provenance (``source``), and
+a ``schema_version``.
+
+See ``designs/flight_exchange_design.md`` for the full wire format and field
+semantics. The Swift counterpart lives in
+``Sources/RZFlight/Briefing/FlightExchange.swift`` and must stay in parity.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from euro_aip.briefing.models.route import Route
+
+# Wire format version. v1 == designs/flight_exchange_design.md.
+# Consumers reject unknown major versions.
+SCHEMA_VERSION = 1
+
+
+@dataclass
+class FlightExchange:
+    """Cross-app flight interchange envelope around a :class:`Route`.
+
+    Attributes:
+        route: The flight route. Serialized verbatim as ``Route.to_dict()`` —
+            the single source of route truth (departure/destination/waypoints/
+            alternates, coords, times, cruise altitude, aircraft type).
+        schema_version: Wire format version (v1 = current).
+        name: Optional display title (e.g. "Oxford -> Sion").
+        aircraft_registration: Aircraft registration — the cross-app field that
+            no app stores at the route level today.
+        source_app: Provenance — emitting app ("weather" | "forms" | "brief").
+        source_flight_id: Sender's native flight id (opaque to the consumer).
+        source_share_code: Present when the sender supports public re-fetch.
+    """
+
+    route: Route
+    schema_version: int = SCHEMA_VERSION
+    name: Optional[str] = None
+    aircraft_registration: Optional[str] = None
+    source_app: Optional[str] = None
+    source_flight_id: Optional[str] = None
+    source_share_code: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Serialize to the language-neutral wire format (snake_case keys).
+
+        Optional envelope fields are omitted when unset, so a minimal flight
+        emits just ``schema_version`` and ``route``. The ``aircraft.type`` key
+        is a convenience mirror of ``route.aircraft_type`` (the route remains
+        the source of truth).
+        """
+        data: dict = {
+            'schema_version': self.schema_version,
+            'route': self.route.to_dict(),
+        }
+
+        if self.name is not None:
+            data['name'] = self.name
+
+        source = {}
+        if self.source_app is not None:
+            source['app'] = self.source_app
+        if self.source_flight_id is not None:
+            source['flight_id'] = self.source_flight_id
+        if self.source_share_code is not None:
+            source['share_code'] = self.source_share_code
+        if source:
+            data['source'] = source
+
+        aircraft = {}
+        if self.aircraft_registration is not None:
+            aircraft['registration'] = self.aircraft_registration
+        # Convenience mirror of route.aircraft_type.
+        if self.route.aircraft_type is not None:
+            aircraft['type'] = self.route.aircraft_type
+        if aircraft:
+            data['aircraft'] = aircraft
+
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'FlightExchange':
+        """Create from the wire format.
+
+        ``aircraft.type`` is ignored on import — ``route.aircraft_type`` is the
+        source of truth, and ``to_dict`` re-mirrors it on the way out.
+        """
+        source = data.get('source') or {}
+        aircraft = data.get('aircraft') or {}
+
+        return cls(
+            route=Route.from_dict(data['route']),
+            schema_version=data.get('schema_version', SCHEMA_VERSION),
+            name=data.get('name'),
+            aircraft_registration=aircraft.get('registration'),
+            source_app=source.get('app'),
+            source_flight_id=source.get('flight_id'),
+            source_share_code=source.get('share_code'),
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"FlightExchange({self.route.departure} -> {self.route.destination}"
+            f", v{self.schema_version})"
+        )

--- a/euro_aip/pyproject.toml
+++ b/euro_aip/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "euro_aip"
-version = "0.10.2"
+version = "0.11.0"
 description = "A library for parsing and managing European AIP (Aeronautical Information Publication) data"
 readme = "README.md"
 authors = [

--- a/euro_aip/tests/briefing/test_flight_exchange.py
+++ b/euro_aip/tests/briefing/test_flight_exchange.py
@@ -1,0 +1,167 @@
+"""Tests for the FlightExchange cross-app interchange model.
+
+Covers the round-trip invariant ``from_dict(to_dict(x)) == x`` and parity with
+the shared wire-format fixtures that the Swift side also decodes
+(``Tests/fixtures/flight_exchange/``). See ``designs/flight_exchange_design.md``.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from euro_aip.briefing.models import FlightExchange, Route, RoutePoint
+from euro_aip.briefing.models.flight_exchange import SCHEMA_VERSION
+
+# Shared cross-platform parity fixtures live at the repo root so both the
+# Python and Swift test suites read the exact same JSON.
+FIXTURES_DIR = Path(__file__).resolve().parents[3] / "Tests" / "fixtures" / "flight_exchange"
+
+
+def load_fixture(name: str) -> dict:
+    with open(FIXTURES_DIR / name) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def full_exchange() -> FlightExchange:
+    """A fully populated FlightExchange matching full.json."""
+    route = Route(
+        departure="EGTK",
+        destination="LSGS",
+        alternates=["LSGG"],
+        waypoints=["BILGO", "XIDIL"],
+        departure_coords=(51.83, -1.32),
+        destination_coords=(46.22, 7.33),
+        alternate_coords={"LSGG": (46.24, 6.11)},
+        waypoint_coords=[
+            RoutePoint(name="BILGO", latitude=48.50, longitude=2.17, point_type="waypoint"),
+            RoutePoint(name="XIDIL", latitude=47.10, longitude=5.40, point_type="waypoint"),
+        ],
+        aircraft_type="P28A",
+        departure_time=datetime(2026, 6, 1, 9, 0, 0, tzinfo=timezone.utc),
+        arrival_time=datetime(2026, 6, 1, 11, 15, 0, tzinfo=timezone.utc),
+        cruise_altitude_ft=8000,
+    )
+    return FlightExchange(
+        route=route,
+        name="Oxford -> Sion",
+        aircraft_registration="HB-ABC",
+        source_app="weather",
+        source_flight_id="egtk_lsgs-2026-06-01-a1b2",
+        source_share_code="Ab3xY9k2",
+    )
+
+
+class TestRoundTrip:
+    """The core invariant: from_dict(to_dict(x)) == x."""
+
+    def test_full_round_trip(self, full_exchange):
+        restored = FlightExchange.from_dict(full_exchange.to_dict())
+        assert restored == full_exchange
+
+    def test_minimal_round_trip(self):
+        fx = FlightExchange(route=Route(departure="EGTF", destination="EGLL"))
+        restored = FlightExchange.from_dict(fx.to_dict())
+        assert restored == fx
+
+    def test_dict_round_trip_is_stable(self, full_exchange):
+        """to_dict -> from_dict -> to_dict yields identical wire output."""
+        once = full_exchange.to_dict()
+        twice = FlightExchange.from_dict(once).to_dict()
+        assert once == twice
+
+
+class TestWireFormat:
+    """Shape of the emitted dictionary."""
+
+    def test_minimal_omits_envelope_keys(self):
+        d = FlightExchange(route=Route(departure="EGTF", destination="EGLL")).to_dict()
+        assert d["schema_version"] == SCHEMA_VERSION
+        assert "route" in d
+        # Optional envelope fields are omitted, not emitted as null.
+        assert "name" not in d
+        assert "source" not in d
+        assert "aircraft" not in d
+
+    def test_route_embedded_verbatim(self, full_exchange):
+        d = full_exchange.to_dict()
+        assert d["route"] == full_exchange.route.to_dict()
+
+    def test_aircraft_type_mirrors_route(self, full_exchange):
+        d = full_exchange.to_dict()
+        assert d["aircraft"]["type"] == full_exchange.route.aircraft_type
+
+    def test_aircraft_block_from_type_only(self):
+        """A route with an aircraft_type but no registration still emits type."""
+        fx = FlightExchange(route=Route(departure="EGTF", destination="EGLL", aircraft_type="C172"))
+        d = fx.to_dict()
+        assert d["aircraft"] == {"type": "C172"}
+
+    def test_source_partial(self):
+        fx = FlightExchange(route=Route(departure="EGTF", destination="EGLL"), source_app="brief")
+        d = fx.to_dict()
+        assert d["source"] == {"app": "brief"}
+
+    def test_schema_version_default(self):
+        fx = FlightExchange(route=Route(departure="EGTF", destination="EGLL"))
+        assert fx.schema_version == SCHEMA_VERSION
+
+
+class TestFromDict:
+    """Decoding behaviour and tolerance."""
+
+    def test_aircraft_type_not_stored_separately(self, full_exchange):
+        """aircraft.type is a mirror — route.aircraft_type is the source of truth."""
+        d = full_exchange.to_dict()
+        d["aircraft"]["type"] = "WRONG"  # mismatched mirror should be ignored
+        fx = FlightExchange.from_dict(d)
+        assert fx.route.aircraft_type == "P28A"
+
+    def test_missing_schema_version_defaults(self):
+        d = {"route": Route(departure="EGTF", destination="EGLL").to_dict()}
+        fx = FlightExchange.from_dict(d)
+        assert fx.schema_version == SCHEMA_VERSION
+
+    def test_null_source_and_aircraft(self):
+        d = {
+            "schema_version": 1,
+            "route": Route(departure="EGTF", destination="EGLL").to_dict(),
+            "source": None,
+            "aircraft": None,
+        }
+        fx = FlightExchange.from_dict(d)
+        assert fx.source_app is None
+        assert fx.aircraft_registration is None
+
+
+class TestParityFixtures:
+    """The committed fixtures are the exact Python wire format (shared with Swift)."""
+
+    def test_full_fixture_matches_emit(self, full_exchange):
+        assert full_exchange.to_dict() == load_fixture("full.json")
+
+    def test_minimal_fixture_matches_emit(self):
+        fx = FlightExchange(route=Route(departure="EGTF", destination="EGLL"))
+        assert fx.to_dict() == load_fixture("minimal.json")
+
+    def test_full_fixture_decodes_and_round_trips(self):
+        data = load_fixture("full.json")
+        fx = FlightExchange.from_dict(data)
+        assert fx.route.departure == "EGTK"
+        assert fx.route.destination == "LSGS"
+        assert fx.name == "Oxford -> Sion"
+        assert fx.aircraft_registration == "HB-ABC"
+        assert fx.source_app == "weather"
+        assert fx.source_share_code == "Ab3xY9k2"
+        assert fx.route.departure_time == datetime(2026, 6, 1, 9, 0, 0, tzinfo=timezone.utc)
+        assert fx.to_dict() == data
+
+    def test_minimal_fixture_decodes(self):
+        fx = FlightExchange.from_dict(load_fixture("minimal.json"))
+        assert fx.route.departure == "EGTF"
+        assert fx.route.destination == "EGLL"
+        assert fx.name is None
+        assert fx.aircraft_registration is None
+        assert fx.source_app is None

--- a/euro_aip/tests/briefing/test_flight_exchange.py
+++ b/euro_aip/tests/briefing/test_flight_exchange.py
@@ -124,6 +124,15 @@ class TestFromDict:
         fx = FlightExchange.from_dict(d)
         assert fx.schema_version == SCHEMA_VERSION
 
+    def test_rejects_newer_schema_version(self):
+        """A newer (unknown) schema version is rejected, not silently decoded."""
+        d = {
+            "schema_version": SCHEMA_VERSION + 1,
+            "route": Route(departure="EGTF", destination="EGLL").to_dict(),
+        }
+        with pytest.raises(ValueError):
+            FlightExchange.from_dict(d)
+
     def test_null_source_and_aircraft(self):
         d = {
             "schema_version": 1,
@@ -165,3 +174,17 @@ class TestParityFixtures:
         assert fx.name is None
         assert fx.aircraft_registration is None
         assert fx.source_app is None
+
+    def test_decodes_swift_style_z_timestamps(self):
+        """Swift's JSONEncoder.iso8601 emits a 'Z' suffix; Python emits +00:00.
+
+        Guards the Swift -> Python import direction: a payload exported by a
+        Swift app must decode here. Relies on datetime.fromisoformat accepting
+        'Z' (Python >= 3.11; package requires >= 3.12).
+        """
+        data = load_fixture("full.json")
+        data["route"]["departure_time"] = "2026-06-01T09:00:00Z"
+        data["route"]["arrival_time"] = "2026-06-01T11:15:00Z"
+        fx = FlightExchange.from_dict(data)
+        assert fx.route.departure_time == datetime(2026, 6, 1, 9, 0, 0, tzinfo=timezone.utc)
+        assert fx.route.arrival_time == datetime(2026, 6, 1, 11, 15, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary

Implements the `FlightExchange` cross-app flight interchange model in both Python and Swift, enabling flights to be exported from one flyfun app and imported into another. This is a language-neutral, round-trippable envelope around the existing `Route` type that adds display metadata, aircraft registration, and provenance information.

## Key Changes

- **Python Implementation** (`euro_aip/briefing/models/flight_exchange.py`):
  - New `FlightExchange` dataclass wrapping `Route` with optional `name`, `aircraft_registration`, and source metadata (`source_app`, `source_flight_id`, `source_share_code`)
  - `to_dict()` serializes to snake_case wire format, omitting unset optional fields
  - `from_dict()` deserializes from wire format, treating `aircraft.type` as a convenience mirror of `route.aircraft_type`
  - Schema versioning support (v1 = current)

- **Swift Implementation** (`Sources/RZFlight/Briefing/FlightExchange.swift`):
  - Parallel `FlightExchange` struct with nested `Source` and `Aircraft` types
  - Custom `Codable` implementation with snake_case key mapping and ISO-8601 date handling
  - `decode(from:)` and `encoded()` convenience methods for JSON round-tripping
  - Memberwise initializer and `CustomStringConvertible` conformance

- **Shared Test Fixtures** (`Tests/fixtures/flight_exchange/`):
  - `full.json`: Comprehensive example with all fields populated (Oxford → Sion flight)
  - `minimal.json`: Minimal example with only required route fields
  - Both fixtures serve as cross-platform parity tests for Python and Swift implementations

- **Comprehensive Test Coverage**:
  - **Python tests** (`euro_aip/tests/briefing/test_flight_exchange.py`):
    - Round-trip invariant: `from_dict(to_dict(x)) == x`
    - Wire format shape validation (optional field omission, nested structure)
    - Fixture parity verification
    - Decoding tolerance (missing schema version defaults, null handling)
  
  - **Swift tests** (`Tests/RZFlightTests/RZFlightFlightExchangeTests.swift`):
    - Decoding of Python-emitted fixtures with full field validation
    - Round-trip invariant across both fixtures and memberwise construction
    - Schema version defaulting behavior
    - Coordinate and time resolution verification

- **Version Bumps**:
  - `euro_aip` version: 0.10.2 → 0.11.0
  - Updated module exports in `__init__.py` files

## Implementation Details

- The `route` JSON object is embedded verbatim from `Route.to_dict()`, ensuring the two models never drift
- `aircraft.type` is a convenience mirror of `route.aircraft_type` on serialization; on deserialization, the route's value is the source of truth
- Optional envelope fields (`name`, `source`, `aircraft`) are completely omitted from JSON when unset, not serialized as `null`
- ISO-8601 UTC timestamps with `+00:00` offset are used for cross-platform date compatibility
- Both implementations use snake_case keys in the wire format per the design specification

https://claude.ai/code/session_01MbisNKG34W6XV79qeLh7iN