### PR TITLE
fix(route-resolver): disable detour gate on closed-loop routes

### DIFF
--- a/euro_aip/euro_aip/models/route_resolver.py
+++ b/euro_aip/euro_aip/models/route_resolver.py
@@ -49,6 +49,11 @@ class RouteResolver:
     DEFAULT_DETOUR_COEF = 0.5
     DEFAULT_DETOUR_CAP_NM = 300.0
 
+    # Departure/destination within this distance are treated as the same
+    # point — a closed-loop (local) flight returning to origin. The detour
+    # gate is meaningless on such routes (see resolve()).
+    CLOSED_LOOP_TOLERANCE_NM = 1.0
+
     def __init__(
         self,
         model: 'EuroAipModel',
@@ -300,13 +305,37 @@ class RouteResolver:
                 name=dep_point.name,
             )
 
+        # Closed-loop detection. A local flight that returns to its origin
+        # (e.g. "EGTF OCK BIG OCK EGTF") has departure ≈ destination, so the
+        # direct route collapses to a zero-length leg. The detour gate, which
+        # measures each middle point against the reference→destination leg,
+        # would then flag *every* outbound waypoint as a maximal detour and
+        # reject it — by definition, nothing on a loop lies on the (nonexistent)
+        # direct line. On such routes we:
+        #   1. disable the detour rejection gate (keep all resolved middles), and
+        #   2. drop the `forward` anchor for disambiguation, so multi-candidate
+        #      names (e.g. SFD: UK vs Venezuela) fall back to
+        #      closest-to-last-resolved-point. That tracks the loop's actual
+        #      path, whereas "minimise detour back to origin" would bias every
+        #      pick toward the origin regardless of where the leg really goes.
+        is_closed_loop = False
+        if dep_point is not None and dest_point is not None:
+            dep_np = NavPoint(
+                latitude=dep_point.latitude,
+                longitude=dep_point.longitude,
+                name=dep_point.name,
+            )
+            _, dep_dest_nm = dep_np.haversine_distance(forward)
+            is_closed_loop = dep_dest_nm < self.CLOSED_LOOP_TOLERANCE_NM
+        disambig_forward = None if is_closed_loop else forward
+
         waypoint_names: List[str] = []
         waypoint_coords: List[RoutePoint] = []
         unresolved: List[str] = []
         rejected: List[dict] = []
         for token in middle_tokens:
             if reference is not None:
-                point = self.resolve_point_near(token, reference, forward=forward)
+                point = self.resolve_point_near(token, reference, forward=disambig_forward)
             else:
                 point = self.resolve_point(token)
 
@@ -316,10 +345,10 @@ class RouteResolver:
                 continue
 
             # Detour gate — only applies when we have both anchors AND a
-            # real leg between them. For closed-loop routes (dep == dest)
-            # leg_nm collapses to 0 and the detour metric reduces to
-            # 2·d(ref, candidate), which would reject every middle point.
-            if reference is not None and forward is not None:
+            # real leg between them. Disabled for closed-loop routes
+            # (dep ≈ dest): the direct route collapses, so the metric would
+            # flag every outbound waypoint as a maximal detour and reject it.
+            if reference is not None and forward is not None and not is_closed_loop:
                 _, leg_nm = reference.haversine_distance(forward)
                 if leg_nm >= 1.0:
                     candidate_np = NavPoint(

--- a/euro_aip/euro_aip/models/route_resolver.py
+++ b/euro_aip/euro_aip/models/route_resolver.py
@@ -318,14 +318,12 @@ class RouteResolver:
         #      closest-to-last-resolved-point. That tracks the loop's actual
         #      path, whereas "minimise detour back to origin" would bias every
         #      pick toward the origin regardless of where the leg really goes.
+        # When both endpoints resolve, `reference` is the departure NavPoint
+        # (set just above) and `forward` is the destination, so the distance
+        # between them is the direct-route length.
         is_closed_loop = False
         if dep_point is not None and dest_point is not None:
-            dep_np = NavPoint(
-                latitude=dep_point.latitude,
-                longitude=dep_point.longitude,
-                name=dep_point.name,
-            )
-            _, dep_dest_nm = dep_np.haversine_distance(forward)
+            _, dep_dest_nm = reference.haversine_distance(forward)
             is_closed_loop = dep_dest_nm < self.CLOSED_LOOP_TOLERANCE_NM
         disambig_forward = None if is_closed_loop else forward
 

--- a/euro_aip/tests/test_models/test_field15_real_routes.py
+++ b/euro_aip/tests/test_models/test_field15_real_routes.py
@@ -328,3 +328,72 @@ def test_route7_star_dropped_unresolved_point_tracked(resolver):
     assert r.departure == "LFRD"
     assert r.destination == "EGTF"
     assert r.waypoints == ["MINQI", "ORTAC", "NEDUL"]
+
+
+# ---------------------------------------------------------------------------
+# Closed-loop (local) flights returning to origin
+# ---------------------------------------------------------------------------
+
+def test_closed_loop_simple_keeps_all_waypoints(resolver):
+    """A local flight back to the origin (departure == destination) must NOT
+    have its waypoints filtered by the detour gate. On "EGTF OCK SFD EGTF"
+    the direct route is zero-length, so every outbound point looks like a
+    maximal detour — the gate must be disabled and all middles kept.
+
+    Regression for the reported bug: such routes previously lost everything
+    after the first waypoint.
+    """
+    route = "EGTF OCK SFD EGTF"
+    r = resolver.resolve(route)
+    assert r.departure == "EGTF"
+    assert r.destination == "EGTF"
+    assert r.waypoints == ["OCK", "SFD"]
+    assert r.rejected_waypoints == []
+
+
+def test_closed_loop_multi_leg_keeps_all_waypoints(resolver):
+    """Mirrors the reported route shape (out via several points, back through
+    OCK to the origin). Every middle — including a repeated waypoint and an
+    airport used as a turning point — must survive."""
+    route = "EGTF OCK SFD EGMD GWC OCK EGTF"
+    r = resolver.resolve(route)
+    assert r.departure == "EGTF"
+    assert r.destination == "EGTF"
+    assert r.waypoints == ["OCK", "SFD", "EGMD", "GWC", "OCK"]
+    assert r.rejected_waypoints == []
+
+
+def test_closed_loop_still_disambiguates_multi_candidate(resolver):
+    """Disabling the detour gate must NOT disable name disambiguation. SFD has
+    a UK candidate (50.76, 0.12) and a Venezuelan one (7.88, -67.44); on a
+    UK local loop the closest-to-last-resolved fallback must still pick UK."""
+    route = "EGTF OCK SFD EGTF"
+    r = resolver.resolve(route)
+    sfd = next(w for w in r.waypoint_coords if w.name == "SFD")
+    assert sfd.latitude == pytest.approx(50.76, abs=0.01)
+    assert sfd.longitude == pytest.approx(0.12, abs=0.01)
+
+
+def test_closed_loop_disambiguates_from_departure_on_first_middle(resolver):
+    """The first middle point in a loop is disambiguated relative to the
+    departure (the initial reference). "EGTF SFD EGTF" must still pick the
+    UK SFD, not Venezuela, even though the gate is off."""
+    route = "EGTF SFD EGTF"
+    r = resolver.resolve(route)
+    assert r.waypoints == ["SFD"]
+    assert r.rejected_waypoints == []
+    sfd = next(w for w in r.waypoint_coords if w.name == "SFD")
+    assert sfd.latitude == pytest.approx(50.76, abs=0.01)
+
+
+def test_non_loop_detour_gate_still_rejects(resolver):
+    """Guard: the closed-loop bypass must not weaken the gate on ordinary
+    point-to-point routes. EGTF→LFAT with the Venezuelan SFD forced far off
+    route still rejects via the detour gate (here SFD resolves to UK and is
+    kept; this simply pins that a normal route is not treated as a loop)."""
+    route = "EGTF SFD LFAT"
+    r = resolver.resolve(route)
+    assert r.departure == "EGTF"
+    assert r.destination == "LFAT"
+    # Not a loop: SFD (UK) is on the way and kept, no special-casing applied.
+    assert r.waypoints == ["SFD"]

--- a/euro_aip/tests/test_models/test_field15_real_routes.py
+++ b/euro_aip/tests/test_models/test_field15_real_routes.py
@@ -386,14 +386,18 @@ def test_closed_loop_disambiguates_from_departure_on_first_middle(resolver):
     assert sfd.latitude == pytest.approx(50.76, abs=0.01)
 
 
-def test_non_loop_detour_gate_still_rejects(resolver):
-    """Guard: the closed-loop bypass must not weaken the gate on ordinary
-    point-to-point routes. EGTF→LFAT with the Venezuelan SFD forced far off
-    route still rejects via the detour gate (here SFD resolves to UK and is
-    kept; this simply pins that a normal route is not treated as a loop)."""
-    route = "EGTF SFD LFAT"
+def test_non_loop_far_waypoint_still_rejected(resolver):
+    """Guard: the closed-loop bypass must not leak into ordinary point-to-point
+    routes. EGTF→EGMD is not a loop (dep ≠ dest), so the detour gate stays
+    active and a genuinely off-path point — Y8, a Canadian NDB at (45.8, -72.4)
+    promoted from AIRWAY — is still rejected. If loop detection ever mis-fired
+    here, the gate would be disabled and this rejection would vanish."""
+    route = "EGTF Y8 EGMD"
     r = resolver.resolve(route)
     assert r.departure == "EGTF"
-    assert r.destination == "LFAT"
-    # Not a loop: SFD (UK) is on the way and kept, no special-casing applied.
-    assert r.waypoints == ["SFD"]
+    assert r.destination == "EGMD"
+    assert r.waypoints == []
+    assert any(
+        rj["name"] == "Y8" and rj["reason"] == "detour_exceeds_threshold"
+        for rj in r.rejected_waypoints
+    )


### PR DESCRIPTION
## Problem

Local flights that return to their origin — e.g. `EGTF OCK BIG EGMD SFD MID OCK EGTF` or `EGTF OCK BIG OCK EGTF` — had most of their waypoints silently filtered out. Departure == destination, so the direct route collapses to a zero-length leg, and the detour gate (which measures each middle waypoint against the `reference → destination` leg) flags every outbound point as a maximal detour and rejects it. By definition, nothing on a loop lies on a nonexistent direct line.

A prior partial guard (`leg_nm >= 1.0`) only shielded the **first** middle waypoint: once one point is accepted the reference advances off the origin, the leg becomes nonzero, and everything after it is rejected. The existing round-trip tests used a single middle waypoint, so they never caught this.

## Fix (`RouteResolver.resolve()`)

- **Detect closed loops** — departure/destination resolve within `CLOSED_LOOP_TOLERANCE_NM` (1nm); covers same-airport and same-field returns.
- **Disable the detour rejection gate** for the whole route when it's a loop — there's no direct line to deviate from.
- **Drop the `forward` anchor** for disambiguation in loops, so multi-candidate names (SFD: UK vs Venezuela; BCN: Brecon vs Barcelona) fall back to closest-to-last-resolved-point, tracking the loop's actual path instead of biasing every pick toward the origin.

## Tests

5 new tests in `test_field15_real_routes.py`:
- multi-leg loop matching the reported shape (all middles kept, repeated waypoint + airport-as-turning-point survive)
- disambiguation still works mid-chain and from departure (UK SFD, not Venezuela)
- non-loop regression guard

Full suite green: **174 euro_aip + 220 downstream weatherbrief** route/resolve tests pass — including the existing `Y8`-rejected and `SFD`/`ABB` disambiguation cases, so point-to-point routes are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)