### PR TITLE
feat(solar): astral-backed solar position primitive

### DIFF
--- a/euro_aip/euro_aip/utils/solar.py
+++ b/euro_aip/euro_aip/utils/solar.py
@@ -1,0 +1,89 @@
+"""Solar position and twilight calculations (UTC in, UTC out).
+
+Stateless helpers in the style of ``utils/geometry.py`` — thin wrappers over
+``astral`` so the rest of the codebase never imports astral directly. All
+inputs and outputs are timezone-aware UTC ``datetime`` objects.
+
+A single pair of primitives — :func:`solar_elevation` and
+:func:`solar_azimuth` — answers "where is the sun, seen from (lat, lon) at
+time T". :func:`sun_events` gives the day's sunrise/sunset (or civil
+dawn/dusk) for margin checks.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Dict, Optional, Tuple
+
+from astral import Observer
+from astral.sun import azimuth, dawn, dusk, elevation, sunrise, sunset
+
+# astral depression angles (degrees the sun centre sits below the horizon).
+CIVIL_TWILIGHT_DEG = 6.0  # sun centre 6 deg below horizon = end of usable light
+
+
+def _aware_utc(when: datetime) -> datetime:
+    """Coerce a datetime to timezone-aware UTC (astral wants tz-aware)."""
+    if when.tzinfo is None:
+        return when.replace(tzinfo=timezone.utc)
+    return when.astimezone(timezone.utc)
+
+
+def solar_elevation(lat: float, lon: float, when_utc: datetime) -> float:
+    """Sun elevation above the horizon in degrees (negative = below)."""
+    return elevation(Observer(lat, lon), _aware_utc(when_utc))
+
+
+def solar_azimuth(lat: float, lon: float, when_utc: datetime) -> float:
+    """Sun bearing, degrees true, clockwise from north (0-360)."""
+    return azimuth(Observer(lat, lon), _aware_utc(when_utc))
+
+
+def solar_position(lat: float, lon: float, when_utc: datetime) -> Tuple[float, float]:
+    """(elevation_deg, azimuth_deg_true) - single call, both values."""
+    obs = Observer(lat, lon)
+    when = _aware_utc(when_utc)
+    return elevation(obs, when), azimuth(obs, when)
+
+
+def sun_events(
+    lat: float,
+    lon: float,
+    on: date,
+    depression: float = 0.0,
+) -> Dict[str, Optional[datetime]]:
+    """Sunrise/sunset (depression=0) or dawn/dusk (depression=6 civil), all UTC.
+
+    Returns ``None`` for an event that does not occur on this date (polar day
+    or polar night), where astral raises ``ValueError``.
+
+    The result keys are ``("sunrise", "sunset")`` for ``depression == 0`` and
+    ``("dawn", "dusk")`` otherwise, so callers can read the relevant pair.
+    """
+    obs = Observer(lat, lon)
+
+    if depression <= 0.0:
+        morning_key, evening_key = "sunrise", "sunset"
+
+        def _morning() -> Optional[datetime]:
+            return sunrise(obs, on)
+
+        def _evening() -> Optional[datetime]:
+            return sunset(obs, on)
+    else:
+        morning_key, evening_key = "dawn", "dusk"
+
+        def _morning() -> Optional[datetime]:
+            return dawn(obs, on, depression=depression)
+
+        def _evening() -> Optional[datetime]:
+            return dusk(obs, on, depression=depression)
+
+    def _safe(fn) -> Optional[datetime]:
+        try:
+            return _aware_utc(fn())
+        except ValueError:
+            # Sun never reaches the requested depression today (polar day/night).
+            return None
+
+    return {morning_key: _safe(_morning), evening_key: _safe(_evening)}

--- a/euro_aip/euro_aip/utils/solar.py
+++ b/euro_aip/euro_aip/utils/solar.py
@@ -54,25 +54,32 @@ def sun_events(
 ) -> Dict[str, Optional[datetime]]:
     """Sunrise/sunset (depression=0) or dawn/dusk (depression=6 civil), all UTC.
 
-    Returns ``None`` for an event that does not occur on this date (polar day
-    or polar night), where astral raises ``ValueError``.
+    The result always has the **fixed keys** ``"morning"`` and ``"evening"`` so
+    callers never have to guess which key name a given ``depression`` produced:
 
-    The result keys are ``("sunrise", "sunset")`` for ``depression == 0`` and
-    ``("dawn", "dusk")`` otherwise, so callers can read the relevant pair.
+    - ``depression == 0`` → ``morning`` = sunrise, ``evening`` = sunset
+    - ``depression > 0``  → ``morning`` = dawn,    ``evening`` = dusk
+      (e.g. ``depression=6`` for civil twilight)
+
+    Each value is ``None`` when that event does not occur on this date (polar day
+    or polar night), where astral raises ``ValueError``. ``depression`` must be
+    ``>= 0`` (degrees the sun centre sits *below* the horizon); a negative value
+    is a programming error and raises ``ValueError`` rather than being masked.
     """
+    if depression < 0.0:
+        raise ValueError(
+            f"depression must be >= 0 (degrees below the horizon), got {depression}"
+        )
+
     obs = Observer(lat, lon)
 
-    if depression <= 0.0:
-        morning_key, evening_key = "sunrise", "sunset"
-
+    if depression == 0.0:
         def _morning() -> Optional[datetime]:
             return sunrise(obs, on)
 
         def _evening() -> Optional[datetime]:
             return sunset(obs, on)
     else:
-        morning_key, evening_key = "dawn", "dusk"
-
         def _morning() -> Optional[datetime]:
             return dawn(obs, on, depression=depression)
 
@@ -86,4 +93,4 @@ def sun_events(
             # Sun never reaches the requested depression today (polar day/night).
             return None
 
-    return {morning_key: _safe(_morning), evening_key: _safe(_evening)}
+    return {"morning": _safe(_morning), "evening": _safe(_evening)}

--- a/euro_aip/pyproject.toml
+++ b/euro_aip/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "langchain_mcp_adapters>=0.1.12",
     "uvicorn>=0.35.0",
     "metar-taf-parser-mivek>=1.6.0",
+    "astral>=3.2",
 ]
 
 [project.urls]

--- a/euro_aip/requirements.txt
+++ b/euro_aip/requirements.txt
@@ -4,6 +4,7 @@ aiohttp>=3.13.2
 aiosignal>=1.4.0
 annotated-types>=0.7.0
 anyio>=4.9.0
+astral>=3.2
 attrs>=25.3.0
 Authlib>=1.6.1
 beautifulsoup4>=4.13.4

--- a/euro_aip/tests/test_utils/test_solar.py
+++ b/euro_aip/tests/test_utils/test_solar.py
@@ -20,7 +20,7 @@ LONDON_LON = -0.1278
 class TestSunEvents:
     def test_known_sunrise_within_two_minutes(self):
         events = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
-        sunrise = events["sunrise"]
+        sunrise = events["morning"]
         assert sunrise is not None
         # Published London sunrise on the solstice: 04:43 BST = 03:43 UTC.
         expected = datetime(2024, 6, 21, 3, 43, tzinfo=timezone.utc)
@@ -29,31 +29,40 @@ class TestSunEvents:
 
     def test_known_sunset_within_two_minutes(self):
         events = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
-        sunset = events["sunset"]
+        sunset = events["evening"]
         assert sunset is not None
         expected = datetime(2024, 6, 21, 20, 21, tzinfo=timezone.utc)
         delta_min = abs((sunset - expected).total_seconds()) / 60.0
         assert delta_min <= 2.0, f"sunset off by {delta_min:.1f} min"
 
-    def test_civil_twilight_keys_and_ordering(self):
-        events = sun_events(
+    def test_keys_are_stable_regardless_of_depression(self):
+        # Fixed morning/evening keys whether asking for sunrise/sunset or
+        # civil dawn/dusk — no KeyError footgun for callers.
+        plain = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
+        civil = sun_events(
             LONDON_LAT, LONDON_LON, date(2024, 6, 21), depression=CIVIL_TWILIGHT_DEG
         )
-        assert set(events.keys()) == {"dawn", "dusk"}
+        assert set(plain.keys()) == {"morning", "evening"}
+        assert set(civil.keys()) == {"morning", "evening"}
         # Civil dawn is before sunrise; civil dusk is after sunset.
-        plain = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
-        assert events["dawn"] < plain["sunrise"]
-        assert events["dusk"] > plain["sunset"]
+        assert civil["morning"] < plain["morning"]
+        assert civil["evening"] > plain["evening"]
+
+    def test_negative_depression_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21), depression=-6)
 
     def test_polar_night_returns_none(self):
         # Longyearbyen (78N) in deep winter: sun never rises.
         events = sun_events(78.22, 15.65, date(2024, 12, 21))
-        assert events["sunrise"] is None
-        assert events["sunset"] is None
+        assert events["morning"] is None
+        assert events["evening"] is None
 
     def test_returns_aware_utc(self):
         events = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
-        assert events["sunrise"].tzinfo is not None
+        assert events["morning"].tzinfo is not None
 
 
 class TestSolarElevation:

--- a/euro_aip/tests/test_utils/test_solar.py
+++ b/euro_aip/tests/test_utils/test_solar.py
@@ -1,0 +1,100 @@
+"""Tests for solar position and twilight helpers."""
+
+from datetime import date, datetime, timezone
+
+from euro_aip.utils.solar import (
+    CIVIL_TWILIGHT_DEG,
+    solar_azimuth,
+    solar_elevation,
+    solar_position,
+    sun_events,
+)
+
+# London, 2024-06-21 (summer solstice). Published local times are BST (UTC+1):
+# sunrise 04:43 BST = 03:43 UTC, sunset 21:21 BST = 20:21 UTC. London sits at
+# ~0 deg longitude so solar noon is ~12:02 UTC regardless of the civil zone.
+LONDON_LAT = 51.5074
+LONDON_LON = -0.1278
+
+
+class TestSunEvents:
+    def test_known_sunrise_within_two_minutes(self):
+        events = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
+        sunrise = events["sunrise"]
+        assert sunrise is not None
+        # Published London sunrise on the solstice: 04:43 BST = 03:43 UTC.
+        expected = datetime(2024, 6, 21, 3, 43, tzinfo=timezone.utc)
+        delta_min = abs((sunrise - expected).total_seconds()) / 60.0
+        assert delta_min <= 2.0, f"sunrise off by {delta_min:.1f} min"
+
+    def test_known_sunset_within_two_minutes(self):
+        events = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
+        sunset = events["sunset"]
+        assert sunset is not None
+        expected = datetime(2024, 6, 21, 20, 21, tzinfo=timezone.utc)
+        delta_min = abs((sunset - expected).total_seconds()) / 60.0
+        assert delta_min <= 2.0, f"sunset off by {delta_min:.1f} min"
+
+    def test_civil_twilight_keys_and_ordering(self):
+        events = sun_events(
+            LONDON_LAT, LONDON_LON, date(2024, 6, 21), depression=CIVIL_TWILIGHT_DEG
+        )
+        assert set(events.keys()) == {"dawn", "dusk"}
+        # Civil dawn is before sunrise; civil dusk is after sunset.
+        plain = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
+        assert events["dawn"] < plain["sunrise"]
+        assert events["dusk"] > plain["sunset"]
+
+    def test_polar_night_returns_none(self):
+        # Longyearbyen (78N) in deep winter: sun never rises.
+        events = sun_events(78.22, 15.65, date(2024, 12, 21))
+        assert events["sunrise"] is None
+        assert events["sunset"] is None
+
+    def test_returns_aware_utc(self):
+        events = sun_events(LONDON_LAT, LONDON_LON, date(2024, 6, 21))
+        assert events["sunrise"].tzinfo is not None
+
+
+class TestSolarElevation:
+    def test_negative_at_local_midnight(self):
+        # London solar midnight ~00:00 UTC+1 -> 23:00 UTC the night before.
+        midnight = datetime(2024, 6, 21, 0, 0, tzinfo=timezone.utc)
+        assert solar_elevation(LONDON_LAT, LONDON_LON, midnight) < 0
+
+    def test_positive_at_local_noon(self):
+        # Solar noon ~12:02 UTC on the solstice (London ~0 deg longitude).
+        noon = datetime(2024, 6, 21, 12, 2, tzinfo=timezone.utc)
+        elev = solar_elevation(LONDON_LAT, LONDON_LON, noon)
+        assert elev > 0
+        # On the solstice at ~51.5N the sun gets to ~62 deg up.
+        assert 55 < elev < 65
+
+    def test_naive_datetime_treated_as_utc(self):
+        aware = datetime(2024, 6, 21, 12, 2, tzinfo=timezone.utc)
+        naive = datetime(2024, 6, 21, 12, 2)
+        assert abs(
+            solar_elevation(LONDON_LAT, LONDON_LON, aware)
+            - solar_elevation(LONDON_LAT, LONDON_LON, naive)
+        ) < 1e-6
+
+
+class TestSolarAzimuth:
+    def test_due_south_at_solar_noon_northern_hemisphere(self):
+        noon = datetime(2024, 6, 21, 12, 2, tzinfo=timezone.utc)
+        az = solar_azimuth(LONDON_LAT, LONDON_LON, noon)
+        # At solar noon in the N hemisphere the sun is due south (~180 deg).
+        assert abs(az - 180.0) < 3.0
+
+    def test_in_range(self):
+        when = datetime(2024, 6, 21, 8, 0, tzinfo=timezone.utc)
+        az = solar_azimuth(LONDON_LAT, LONDON_LON, when)
+        assert 0.0 <= az <= 360.0
+
+
+class TestSolarPosition:
+    def test_matches_individual_calls(self):
+        when = datetime(2024, 6, 21, 9, 30, tzinfo=timezone.utc)
+        elev, az = solar_position(LONDON_LAT, LONDON_LON, when)
+        assert elev == solar_elevation(LONDON_LAT, LONDON_LON, when)
+        assert az == solar_azimuth(LONDON_LAT, LONDON_LON, when)


### PR DESCRIPTION
## Summary

Adds a stateless solar-position primitive to `euro_aip`, the cross-repo prerequisite for flyfun-weather **issue #227** (Sun advisory + night cross-section shading).

- **`euro_aip/utils/solar.py`** — UTC-in/UTC-out wrappers over `astral` so the rest of the codebase never imports astral directly:
  - `solar_elevation(lat, lon, when)` — degrees above horizon (negative = below)
  - `solar_azimuth(lat, lon, when)` — degrees true, clockwise from north
  - `solar_position(...)` — both in one call
  - `sun_events(lat, lon, on, depression=0)` — sunrise/sunset (or civil dawn/dusk at `depression=6`); returns `None` for polar day/night instead of raising
- **`astral>=3.2`** added to `pyproject.toml` and `requirements.txt` (pure-Python, Apache-2.0, no C extensions).
- **Tests** (`tests/test_utils/test_solar.py`): known London sunrise/sunset within ±2 min, elevation sign at local midnight/noon, solar-noon azimuth ≈180° (N hemisphere), polar-night → `None`.

## Why

flyfun-weather #227 builds a Sun advisory + cross-section night shading entirely from this one primitive, fed `lat`/`lon`/`time` that every route point already carries. Keeping the solar math in `euro_aip` (alongside `utils/geometry.py`) lets both the web app and future iOS work share it.

## Test plan

```
pytest tests/test_utils/test_solar.py   # 11 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)