### PR TITLE
Add border formalities helper for Schengen/EU-customs membership

### DIFF
--- a/designs/borders.md
+++ b/designs/borders.md
@@ -1,0 +1,90 @@
+# Border-area membership & crossing requirements
+
+`euro_aip.borders` is pure, offline reference data (no network, no I/O) that
+answers a single question consumers keep re-encoding: **what border formalities
+apply when flying between two countries?**
+
+Two overlapping-but-distinct European blocs drive the answer:
+
+- the **Schengen area** → drives whether **immigration** (passport) applies;
+- the **EU customs union** → drives whether **customs** applies.
+
+The memberships do not coincide:
+
+- `CH`, `NO`, `IS`, `LI` are Schengen but **outside** the EU customs union.
+- `CY`, `IE` are in the EU customs union but **outside** Schengen.
+
+So France→Switzerland needs customs but no immigration, while France→Ireland
+needs immigration but no customs.
+
+## API
+
+```python
+from euro_aip.borders import (
+    is_schengen,            # (cc) -> bool
+    is_eu_customs_union,    # (cc) -> bool
+    is_known,               # (cc) -> bool  (in either table)
+    crossing_requirements,  # (from_cc, to_cc) -> CrossingRequirements
+)
+```
+
+All predicates take ISO-3166-1 alpha-2 codes and are case-insensitive.
+
+`crossing_requirements(from_cc, to_cc)` returns a frozen dataclass:
+
+```python
+CrossingRequirements(
+    immigration_required: bool,  # not (both Schengen)
+    customs_required: bool,      # not (both EU customs union)
+    from_known: bool,            # origin found in the reference tables
+    to_known: bool,              # destination found in the reference tables
+)
+```
+
+Rules:
+
+- `immigration_required = not (is_schengen(from) and is_schengen(to))`
+- `customs_required     = not (is_eu_customs_union(from) and is_eu_customs_union(to))`
+- Same country → both `False` (domestic flight, no border).
+- Unknown country → the `*_required` flags default to `True` (treated as outside
+  every bloc), but `from_known` / `to_known` is `False` so callers can report
+  "couldn't determine" rather than assume an open border.
+
+### Examples
+
+| From → To | immigration | customs | note |
+|-----------|:-----------:|:-------:|------|
+| FR → GB   | ✓ | ✓ | GB in neither table (`to_known=False`) |
+| FR → CH   | ✗ | ✓ | Schengen but not EU-customs |
+| FR → IE   | ✓ | ✗ | EU-customs but not Schengen |
+| FR → DE   | ✗ | ✗ | both blocs |
+
+```python
+>>> crossing_requirements("FR", "CH")
+CrossingRequirements(immigration_required=False, customs_required=True,
+                     from_known=True, to_known=True)
+```
+
+### Airport convenience properties
+
+`Airport` exposes two derived properties (from `iso_country`). Both return
+`None` when the country is unknown, so "outside the area" stays distinct from
+"couldn't determine":
+
+```python
+airport.is_schengen           # Optional[bool]
+airport.is_eu_customs_union    # Optional[bool]
+```
+
+## Known edge cases (caller may special-case)
+
+- **IE↔GB Common Travel Area** — the rule flags immigration (GB is not
+  Schengen), but the CTA means there is no immigration check in practice.
+- **Channel Islands / Isle of Man** (`JE`, `GG`, `IM`) — outside both blocs, so
+  a flight to/from the EU reads as customs + immigration, which is correct.
+
+## Maintenance
+
+Bloc memberships change — **review the tables in `euro_aip/borders.py`
+annually**. Bulgaria and Romania fully joined Schengen in 2024–2025; Croatia
+joined in 2023. Sources are cited in the module docstring.

--- a/euro_aip/README.md
+++ b/euro_aip/README.md
@@ -24,6 +24,7 @@ The `euro_aip` library provides:
 - 💾 **Transactions** - Atomic updates with automatic rollback
 - ⚡ **Bulk Operations** - High-performance batch processing
 - 🏗️ **Builder Pattern** - Fluent API for constructing airports
+- 🛂 **Border Formalities** - Schengen / EU-customs membership + crossing-requirements helper
 - 🔄 **Full Backward Compatibility** - Legacy API still supported
 
 ### What Can You Use It For?
@@ -100,12 +101,30 @@ airport = model.airport_builder("EGLL") \
     .commit()
 ```
 
+#### Border Formalities - Crossing Requirements
+```python
+from euro_aip.borders import crossing_requirements, is_schengen
+
+# What border formalities apply for a France -> Switzerland flight?
+req = crossing_requirements("FR", "CH")
+print(req.immigration_required)  # False (both Schengen)
+print(req.customs_required)      # True  (CH is outside the EU customs union)
+
+# Unknown countries surface as *_known=False rather than assuming an open border
+crossing_requirements("FR", "GB").to_known  # False
+
+# Derived airport convenience properties (from iso_country)
+model.airports['LSGG'].is_schengen           # True
+model.airports['LSGG'].is_eu_customs_union   # False
+```
+
 ### Documentation
 
 Full documentation available in `designs/`:
 - **[Quick Start Guide](designs/QUICK_START.md)** - Get started in 5 minutes
 - **[Query API Documentation](designs/models_query_api_documentation.md)** - Complete query reference
 - **[Builder API Guide](designs/builder_api_guide.md)** - Building and modifying data
+- **[Border Formalities](designs/borders.md)** - Schengen / EU-customs membership & crossing requirements
 - **[Migration Guide](designs/migration_guide.md)** - Upgrading from legacy API
 
 ---

--- a/euro_aip/euro_aip/borders.py
+++ b/euro_aip/euro_aip/borders.py
@@ -1,0 +1,157 @@
+"""Country border-area membership and crossing-requirements helpers.
+
+Pure, offline reference data (no network, no I/O) answering a single
+question consumers keep re-encoding: what **border formalities** —
+immigration, customs, both, or neither — apply when flying between two
+countries? That is a function of two overlapping-but-distinct European
+blocs:
+
+- the **Schengen area** (passport-free travel → drives *immigration*), and
+- the **EU customs union** (goods move duty-free → drives *customs*).
+
+The two memberships do not coincide. CH/NO/IS/LI are Schengen but outside
+the EU customs union; CY/IE are in the EU customs union but outside
+Schengen. So a France→Switzerland flight needs customs but no immigration,
+while France→Ireland needs immigration but no customs.
+
+All predicates take ISO-3166-1 alpha-2 country codes (case-insensitive).
+Unknown codes return ``False`` from the predicates but are surfaced through
+``from_known`` / ``to_known`` on :func:`crossing_requirements` so callers
+can say "couldn't determine" rather than silently assume an open border.
+
+.. note::
+   **Review annually.** Bloc memberships change — Bulgaria and Romania
+   fully joined Schengen on 2024-03-31 (air/sea) and 2025-01-01 (land),
+   and Croatia joined on 2023-01-01. Re-check these tables against the
+   sources below at least once a year.
+
+Sources (verified 2026-07):
+- Schengen area members —
+  https://home-affairs.ec.europa.eu/policies/schengen-borders-and-visa/schengen-area_en
+- EU customs union / EU member states —
+  https://taxation-customs.ec.europa.eu/customs-4/eu-customs-union_en
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import FrozenSet, Optional
+
+# --- Reference tables --------------------------------------------------------
+# ISO-3166-1 alpha-2 codes. Keep these two sets as the single source of truth;
+# everything else derives from them.
+
+#: Schengen area member states. CH/NO/IS/LI are Schengen but NOT EU-customs.
+SCHENGEN: FrozenSet[str] = frozenset({
+    "AT", "BE", "BG", "HR", "CZ", "DK", "EE", "FI", "FR", "DE", "GR", "HU",
+    "IS", "IT", "LV", "LI", "LT", "LU", "MT", "NL", "NO", "PL", "PT", "RO",
+    "SK", "SI", "ES", "SE", "CH",
+})
+
+#: EU customs union members (the EU-27). CY/IE are EU-customs but NOT Schengen.
+EU_CUSTOMS_UNION: FrozenSet[str] = frozenset({
+    "AT", "BE", "BG", "HR", "CY", "CZ", "DK", "EE", "FI", "FR", "DE", "GR",
+    "HU", "IE", "IT", "LV", "LT", "LU", "MT", "NL", "PL", "PT", "RO", "SK",
+    "SI", "ES", "SE",
+})
+
+#: Union of both tables — the set of countries we can make a statement about.
+_KNOWN: FrozenSet[str] = SCHENGEN | EU_CUSTOMS_UNION
+
+
+def _normalize(cc: Optional[str]) -> Optional[str]:
+    """Upper-case and strip a country code; ``None`` for empty/falsy input."""
+    if not cc:
+        return None
+    normalized = cc.strip().upper()
+    return normalized or None
+
+
+def is_known(cc: str) -> bool:
+    """True if ``cc`` appears in either membership table (Schengen or EU-customs).
+
+    A country can be "known" here without being in a given bloc — e.g. ``IE``
+    is known (it is in the EU customs union) even though it is not Schengen.
+    """
+    return _normalize(cc) in _KNOWN
+
+
+def is_schengen(cc: str) -> bool:
+    """True if ``cc`` is a Schengen area member (ISO-3166-1 alpha-2, case-insensitive)."""
+    return _normalize(cc) in SCHENGEN
+
+
+def is_eu_customs_union(cc: str) -> bool:
+    """True if ``cc`` is an EU customs union member (ISO-3166-1 alpha-2, case-insensitive)."""
+    return _normalize(cc) in EU_CUSTOMS_UNION
+
+
+@dataclass(frozen=True)
+class CrossingRequirements:
+    """Border formalities for a flight from one country to another.
+
+    Attributes:
+        immigration_required: Immigration/passport check applies (i.e. the pair
+            is not both-Schengen).
+        customs_required: A customs declaration applies (i.e. the pair is not
+            both-in-the-EU-customs-union).
+        from_known: The origin country was found in the reference tables.
+        to_known: The destination country was found in the reference tables.
+
+    When ``from_known`` or ``to_known`` is ``False`` the ``*_required`` flags
+    are computed as if the unknown country were outside every bloc (so they
+    default to ``True``). Callers that want to distinguish "definitely a border"
+    from "couldn't determine" should check the ``*_known`` flags first.
+    """
+
+    immigration_required: bool
+    customs_required: bool
+    from_known: bool
+    to_known: bool
+
+
+def crossing_requirements(from_cc: str, to_cc: str) -> CrossingRequirements:
+    """Border formalities for a flight from ``from_cc`` to ``to_cc``.
+
+    Both arguments are ISO-3166-1 alpha-2 codes (case-insensitive):
+
+    - ``immigration_required = not (is_schengen(from) and is_schengen(to))``
+    - ``customs_required     = not (is_eu_customs_union(from) and is_eu_customs_union(to))``
+    - Same country → both ``False`` (no domestic border), even for a country
+      that is outside both blocs, and even if the code is unknown.
+    - Unknown country → ``from_known`` / ``to_known`` is ``False`` so callers can
+      report "couldn't determine" instead of assuming an open border.
+
+    Known edge cases the caller may want to special-case (the rule below does
+    not encode them, because in aviation terms they are correct as-is):
+
+    - **IE↔GB Common Travel Area** — this rule flags immigration (GB is not
+      Schengen), but the CTA means there is no immigration check in practice.
+    - **Channel Islands / Isle of Man** (``JE``, ``GG``, ``IM``) — outside both
+      blocs, so a flight to/from the EU reads as customs + immigration, which
+      is correct.
+    """
+    f = _normalize(from_cc)
+    t = _normalize(to_cc)
+
+    from_known = f in _KNOWN
+    to_known = t in _KNOWN
+
+    # Same country (including an unknown-but-identical code) → no border.
+    if f is not None and f == t:
+        return CrossingRequirements(
+            immigration_required=False,
+            customs_required=False,
+            from_known=from_known,
+            to_known=to_known,
+        )
+
+    immigration_required = not (f in SCHENGEN and t in SCHENGEN)
+    customs_required = not (f in EU_CUSTOMS_UNION and t in EU_CUSTOMS_UNION)
+
+    return CrossingRequirements(
+        immigration_required=immigration_required,
+        customs_required=customs_required,
+        from_known=from_known,
+        to_known=to_known,
+    )

--- a/euro_aip/euro_aip/models/airport.py
+++ b/euro_aip/euro_aip/models/airport.py
@@ -106,6 +106,32 @@ class Airport:
         from euro_aip.models.procedure_collection import ProcedureCollection
         return ProcedureCollection(self.procedures)
 
+    @property
+    def is_schengen(self) -> Optional[bool]:
+        """Whether this airport's country is in the Schengen area.
+
+        Derived from ``iso_country``. Returns ``None`` when the country is
+        unknown (missing or not in the reference tables) so callers can tell
+        "outside Schengen" apart from "couldn't determine".
+        """
+        from euro_aip.borders import is_known, is_schengen
+        if not self.iso_country or not is_known(self.iso_country):
+            return None
+        return is_schengen(self.iso_country)
+
+    @property
+    def is_eu_customs_union(self) -> Optional[bool]:
+        """Whether this airport's country is in the EU customs union.
+
+        Derived from ``iso_country``. Returns ``None`` when the country is
+        unknown (missing or not in the reference tables) so callers can tell
+        "outside the customs union" apart from "couldn't determine".
+        """
+        from euro_aip.borders import is_eu_customs_union, is_known
+        if not self.iso_country or not is_known(self.iso_country):
+            return None
+        return is_eu_customs_union(self.iso_country)
+
     def get_authority(self) -> str:
         """Get the authority for the airport."""
         # get the authority from the ICAO code first 2 letters

--- a/euro_aip/tests/test_borders.py
+++ b/euro_aip/tests/test_borders.py
@@ -1,0 +1,154 @@
+"""Tests for country border-area membership and crossing-requirements helpers."""
+
+import pytest
+
+from euro_aip.borders import (
+    EU_CUSTOMS_UNION,
+    SCHENGEN,
+    CrossingRequirements,
+    crossing_requirements,
+    is_eu_customs_union,
+    is_known,
+    is_schengen,
+)
+from euro_aip.models.airport import Airport
+
+
+class TestMembershipPredicates:
+    def test_schengen_and_customs_core_member(self):
+        # France is in both blocs.
+        assert is_schengen("FR")
+        assert is_eu_customs_union("FR")
+
+    def test_schengen_not_customs(self):
+        # Switzerland: Schengen but outside the EU customs union.
+        assert is_schengen("CH")
+        assert not is_eu_customs_union("CH")
+
+    def test_customs_not_schengen(self):
+        # Ireland and Cyprus: EU customs union but outside Schengen.
+        assert is_eu_customs_union("IE")
+        assert not is_schengen("IE")
+        assert is_eu_customs_union("CY")
+        assert not is_schengen("CY")
+
+    def test_case_insensitive(self):
+        assert is_schengen("fr")
+        assert is_schengen(" De ")
+        assert is_eu_customs_union("ie")
+
+    def test_unknown_and_empty(self):
+        assert not is_schengen("XX")
+        assert not is_eu_customs_union("XX")
+        assert not is_schengen("")
+        assert not is_schengen(None)
+
+    def test_is_known(self):
+        assert is_known("FR")
+        assert is_known("IE")  # customs-only is still "known"
+        assert is_known("CH")  # schengen-only is still "known"
+        assert not is_known("GB")
+        assert not is_known("XX")
+        assert not is_known(None)
+
+    def test_reference_tables_edge_membership(self):
+        # Guard rails against accidental table drift on the tricky members.
+        assert {"CH", "NO", "IS", "LI"} <= SCHENGEN
+        assert not ({"CH", "NO", "IS", "LI"} & EU_CUSTOMS_UNION)
+        assert {"CY", "IE"} <= EU_CUSTOMS_UNION
+        assert not ({"CY", "IE"} & SCHENGEN)
+
+
+class TestCrossingRequirements:
+    # Acceptance criteria rows from the issue.
+
+    def test_fr_gb_immigration_and_customs(self):
+        req = crossing_requirements("FR", "GB")
+        assert req.immigration_required is True
+        assert req.customs_required is True
+        assert req.from_known is True
+        assert req.to_known is False  # GB is in neither table
+
+    def test_fr_ch_customs_only(self):
+        req = crossing_requirements("FR", "CH")
+        assert req.immigration_required is False
+        assert req.customs_required is True
+        assert req.from_known is True
+        assert req.to_known is True
+
+    def test_fr_ie_immigration_only(self):
+        req = crossing_requirements("FR", "IE")
+        assert req.immigration_required is True
+        assert req.customs_required is False
+        assert req.from_known is True
+        assert req.to_known is True
+
+    def test_fr_de_no_formalities(self):
+        req = crossing_requirements("FR", "DE")
+        assert req.immigration_required is False
+        assert req.customs_required is False
+        assert req.from_known is True
+        assert req.to_known is True
+
+    def test_fr_unknown_to_not_known(self):
+        req = crossing_requirements("FR", "XX")
+        assert req.to_known is False
+        assert req.from_known is True
+        # Unknown destination is treated as outside every bloc -> both flags set.
+        assert req.immigration_required is True
+        assert req.customs_required is True
+
+    def test_same_country_no_border(self):
+        req = crossing_requirements("FR", "FR")
+        assert req.immigration_required is False
+        assert req.customs_required is False
+        assert req.from_known is True
+        assert req.to_known is True
+
+    def test_same_unknown_country_no_border(self):
+        # Identical codes mean a domestic flight, even for an unknown country.
+        req = crossing_requirements("GB", "GB")
+        assert req.immigration_required is False
+        assert req.customs_required is False
+        assert req.from_known is False
+        assert req.to_known is False
+
+    def test_case_insensitive_pair(self):
+        assert crossing_requirements("fr", "de") == crossing_requirements("FR", "DE")
+
+    def test_is_dataclass_instance(self):
+        assert isinstance(crossing_requirements("FR", "DE"), CrossingRequirements)
+
+    def test_channel_islands_vs_eu(self):
+        # Jersey is outside both blocs -> customs + immigration vs France.
+        req = crossing_requirements("JE", "FR")
+        assert req.immigration_required is True
+        assert req.customs_required is True
+        assert req.from_known is False
+
+
+class TestAirportConvenienceProperties:
+    def test_schengen_customs_country(self):
+        airport = Airport(ident="LFPG", iso_country="FR")
+        assert airport.is_schengen is True
+        assert airport.is_eu_customs_union is True
+
+    def test_schengen_only_country(self):
+        airport = Airport(ident="LSGG", iso_country="CH")
+        assert airport.is_schengen is True
+        assert airport.is_eu_customs_union is False
+
+    def test_customs_only_country(self):
+        airport = Airport(ident="EIDW", iso_country="IE")
+        assert airport.is_schengen is False
+        assert airport.is_eu_customs_union is True
+
+    def test_unknown_country_is_none(self):
+        airport = Airport(ident="EGLL", iso_country="GB")
+        assert airport.is_schengen is None
+        assert airport.is_eu_customs_union is None
+
+    def test_missing_country_is_none(self):
+        airport = Airport(ident="ZZZZ", iso_country=None)
+        assert airport.is_schengen is None
+        assert airport.is_eu_customs_union is None


### PR DESCRIPTION
## Summary

Adds a new `euro_aip.borders` module providing pure, offline reference data to answer a common question: **what border formalities (immigration, customs, both, or neither) apply when flying between two countries?**

The module encodes membership in two overlapping-but-distinct European blocs:
- **Schengen area** (drives immigration/passport requirements)
- **EU customs union** (drives customs requirements)

Since memberships don't coincide (e.g., Switzerland is Schengen but outside the EU customs union; Ireland is in the customs union but outside Schengen), the helper correctly identifies which formalities apply for any country pair.

## Key Changes

- **New module `euro_aip/borders.py`**
  - Reference tables for Schengen area and EU customs union members (ISO-3166-1 alpha-2 codes)
  - Predicates: `is_schengen()`, `is_eu_customs_union()`, `is_known()`
  - Main function: `crossing_requirements(from_cc, to_cc)` → `CrossingRequirements` dataclass with:
    - `immigration_required`: whether passport check applies
    - `customs_required`: whether customs declaration applies
    - `from_known` / `to_known`: whether countries were found in reference tables
  - Case-insensitive country code handling
  - Unknown countries default to `True` for both formalities but surface as `*_known=False` so callers can distinguish "definitely a border" from "couldn't determine"

- **Airport convenience properties** (`euro_aip/models/airport.py`)
  - `Airport.is_schengen` → `Optional[bool]` (derived from `iso_country`)
  - `Airport.is_eu_customs_union` → `Optional[bool]` (derived from `iso_country`)
  - Returns `None` for unknown/missing countries to keep "outside the area" distinct from "couldn't determine"

- **Comprehensive test suite** (`tests/test_borders.py`)
  - Membership predicate tests (core members, edge cases, case-insensitivity)
  - Crossing requirements acceptance criteria (FR→GB, FR→CH, FR→IE, FR→DE, etc.)
  - Same-country domestic flight handling
  - Unknown country handling
  - Airport property tests

- **Documentation**
  - Design document (`designs/borders.md`) with API reference, examples, and maintenance notes
  - Updated `README.md` with border formalities feature and usage examples
  - Inline docstrings with sources and annual review reminder

## Notable Implementation Details

- Reference tables are the single source of truth; all predicates derive from them
- Same-country flights always return `False` for both formalities (no domestic border), even for unknown countries
- Unknown countries are treated as outside every bloc (both flags default to `True`), but `*_known` flags allow callers to report "couldn't determine" rather than silently assume an open border
- Module includes edge case documentation (IE↔GB Common Travel Area, Channel Islands) that callers may want to special-case
- Includes maintenance reminder: bloc memberships change (Bulgaria/Romania joined Schengen 2024–2025, Croatia in 2023)

https://claude.ai/code/session_01HxyKNnp1aVZuPjGwusdQpT